### PR TITLE
Remove syslogd from dhcp server

### DIFF
--- a/nixos/pi5/default.nix
+++ b/nixos/pi5/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, hostname, ... }:
+{ pkgs, ... }:
 let
   mainIface = "end0";
   guestIface = "wlan0";

--- a/nixos/pi5/default.nix
+++ b/nixos/pi5/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, hostname, ... }:
 let
   mainIface = "end0";
   guestIface = "wlan0";
@@ -126,15 +126,8 @@ in
     53 # DNS
     67 # DHCP
     69 # TFTP
-    514 # syslog
   ];
   systemd.tmpfiles.rules = [
     "L+ /var/lib/dnsmasq/tftp/netboot.xyz.efi - - - - ${pkgs.netbootxyz-efi}"
   ];
-
-  # syslogd -r for remote debugging
-  services.syslogd = {
-    enable = true;
-    enableNetworkInput = true;
-  };
 }


### PR DESCRIPTION
- **Revert "Run syslogd -f on dhcp node"**
- **nit: Remove unused hostname arg**
