### PR TITLE
Adjust config for office setup to use ethernet if avail

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -39,7 +39,7 @@
     shell = pkgs.zsh;
   };
 
-  networking = {
+  networking = lib.optionalAttrs (!isWork) {
     knownNetworkServices = [ "Wi-Fi" ];
     dhcpClientId = hostname;
   };

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -40,7 +40,10 @@
   };
 
   networking = lib.optionalAttrs (!isWork) {
-    knownNetworkServices = [ "Wi-Fi" ];
+    knownNetworkServices = [
+      "Ethernet"
+      "Wi-Fi"
+    ];
     dhcpClientId = hostname;
   };
 

--- a/nixos/frame/default.nix
+++ b/nixos/frame/default.nix
@@ -8,7 +8,7 @@
   services.fwupd.enable = true;
   hardware.enableRedistributableFirmware = true;
 
-  networking.wireless.enable = true;
+  networking.wireless.enable = false;
   networking.wireless.secretsFile = "/etc/wireless.secrets";
   networking.wireless.networks = {
     booxter = {

--- a/nixos/pi5/default.nix
+++ b/nixos/pi5/default.nix
@@ -79,6 +79,9 @@ in
         # infra
         "7c:b7:7b:04:05:99,mdx,192.168.10.100" # MDX-8
 
+        # better aliases for work machines with forced client id
+        "id:JGWXHWDL4X,mlt,192.168.11.2"
+
         # DON'T USE 192.168.15.0/24 for nixarr compatibility
         # TODO: migrate all internal nodes out of .15 range for nixarr compatibility
         # TODO: modify nixarr to allow using a different range for wg iface?

--- a/nixos/pi5/default.nix
+++ b/nixos/pi5/default.nix
@@ -79,12 +79,6 @@ in
         # infra
         "7c:b7:7b:04:05:99,mdx,192.168.10.100" # MDX-8
 
-        # clients
-        "id:mmini,mmini,192.168.11.1"
-        "id:JGWXHWDL4X,mlt,192.168.11.2" # use something more readable
-        "id:mair,mair,192.168.11.3"
-        "id:frame,frame,192.168.11.4"
-
         # DON'T USE 192.168.15.0/24 for nixarr compatibility
         # TODO: migrate all internal nodes out of .15 range for nixarr compatibility
         # TODO: modify nixarr to allow using a different range for wg iface?


### PR DESCRIPTION
- **dhcp: don't hardcode ips for desktops**
- **don't set darwin network config on work machines**
- **Set dhcp client for Ethernet on darwin machines**
- **dhcp: restore mlt alias for work laptop**
- **Disable wifi on frame machine**
