### PR TITLE
darwin: don't configure Ethernet interface on mair laptop

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -39,11 +39,16 @@
     shell = pkgs.zsh;
   };
 
+  # Can't configure networking on managed work devices
   networking = lib.optionalAttrs (!isWork) {
-    knownNetworkServices = [
-      "Ethernet"
-      "Wi-Fi"
-    ];
+    knownNetworkServices =
+      # mair - laptop - doesn't have builtin ethernet
+      lib.optionals (hostname != "mair") [
+        "Ethernet"
+      ]
+      ++ [
+        "Wi-Fi"
+      ];
     dhcpClientId = hostname;
   };
 


### PR DESCRIPTION
It doesn't have the interface. A dongle would have a different name
(Thunderbolt Ethernet?) anyway.
