### PR TITLE
Reset HOME when running sudo on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ darwin-build-target:
 	$(call nix-config-action,,.#darwinConfigurations.$(WHAT).system)
 
 darwin-switch:
-	sudo nix run nix-darwin -- switch --flake .#$(shell hostname) $(ARGS)
+	sudo -H nix run nix-darwin -- switch --flake .#$(shell hostname) $(ARGS)
 
 switch:
 	@if [ "$(shell uname -s)" = "Darwin" ]; then \


### PR DESCRIPTION
This will avoid:

warning: $HOME ('/Users/ihrachyshka') is not owned by you, falling back
to the one defined in the 'passwd' file ('/var/root')
