### PR TITLE
overlays: drop obsolete NUT master override

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -483,22 +483,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-master": {
-      "locked": {
-        "lastModified": 1771236797,
-        "narHash": "sha256-wQoZEyF/e1HhyqesyTZbIjR827O/OcsJ/Kbs0J7POCE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c724b7ff6d7ce10b6e88358a555b620448cf0558",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-quartz-wm": {
       "locked": {
         "lastModified": 1771462627,
@@ -659,7 +643,6 @@
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-25_11": "nixpkgs-25_11",
         "nixpkgs-huntarr": "nixpkgs-huntarr",
-        "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-quartz-wm": "nixpkgs-quartz-wm",
         "nixvim": "nixvim",
         "nur": "nur",

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-master.url = "github:NixOS/nixpkgs/master";
     nixpkgs-25_11.url = "github:NixOS/nixpkgs/release-25.11";
 
     # Use staging-next if needed

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -16,7 +16,6 @@
 
       pkgs = getPkgs inputs.nixpkgs;
       pkgsLldb = getPkgs inputs.debugserver;
-      pkgsMaster = getPkgs inputs.nixpkgs-master;
       pkgsRelease = getPkgs inputs.nixpkgs-25_11;
       pkgsQuartzWm = getPkgs inputs.nixpkgs-quartz-wm;
       pkgsHuntarr = getPkgs inputs.nixpkgs-huntarr;
@@ -83,9 +82,6 @@
       });
     }
     // inputs.nixpkgs.lib.optionalAttrs prev.stdenv.isDarwin {
-      # Pull NUT from master for now for darwin support.
-      inherit (pkgsMaster) nut;
-
       # Backport until https://github.com/NixOS/nixpkgs/pull/488112 lands in our pinned nixpkgs.
       firefox = patchFirefoxDarwinWrapper prev.firefox;
 


### PR DESCRIPTION
Summary:
- remove Darwin-only nut override from overlays/default.nix
- remove now-unused nixpkgs-master flake input
- update flake.lock accordingly

Why:
- nut from pinned nixpkgs and nixpkgs-master is currently identical (version 2.8.4 and same derivation), so override is redundant.