### PR TITLE
darwin: Set home dir for prometheus exporter

### DIFF
--- a/darwin/_mixins/observability-client/default.nix
+++ b/darwin/_mixins/observability-client/default.nix
@@ -21,6 +21,8 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
+        users.users._prometheus-node-exporter.home = lib.mkForce "/private/var/lib/prometheus-node-exporter";
+
         services.prometheus.exporters.node = {
           enable = true;
           listenAddress = cfg.nodeExporter.listenAddress;


### PR DESCRIPTION
```
error: config contains the wrong home directory for
_prometheus-node-exporter, aborting activation

nix-darwin does not support changing the home directory of existing users.
```