### PR TITLE
NFS: harden a bit

### DIFF
--- a/nixos/beast/nfs.nix
+++ b/nixos/beast/nfs.nix
@@ -1,11 +1,17 @@
 { hostInventory, lib, ... }:
 let
-  nfsSubnet = hostInventory.site.lan.cidr;
   nfsPort = hostInventory.site.ports.nfs;
+  srvarrNfsAddress = hostInventory.dhcpReservationsByHostname.prox-srvarrvm.ip;
+  cacheNfsAddress = hostInventory.dhcpReservationsByHostname.prox-cachevm.ip;
 
   # Pin export IDs so clients see stable export identities across server restarts.
   mkNfsExport =
-    { path, fsid }: "${path} ${nfsSubnet}(rw,async,no_subtree_check,fsid=${toString fsid})";
+    {
+      path,
+      client,
+      fsid,
+    }:
+    "${path} ${client}(rw,async,no_subtree_check,fsid=${toString fsid})";
 in
 {
   # NFS exports matching existing clients.
@@ -14,10 +20,12 @@ in
     exports = ''
       ${mkNfsExport {
         path = "/volume2/Media";
+        client = srvarrNfsAddress;
         fsid = 10; # media export
       }}
       ${mkNfsExport {
         path = "/volume2/nix-cache";
+        client = cacheNfsAddress;
         fsid = 11; # binary cache export
       }}
     '';

--- a/nixos/beast/nfs.nix
+++ b/nixos/beast/nfs.nix
@@ -45,5 +45,4 @@ in
   services.rpcbind.enable = lib.mkForce false;
 
   networking.firewall.allowedTCPPorts = [ nfsPort ];
-  networking.firewall.allowedUDPPorts = [ nfsPort ];
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -96,6 +96,9 @@ in
     networking.dhcpcd.extraConfig = ''
       clientid ${hostname}
     '';
+    # All current NFS use is v4-only. NixOS enables rpcbind automatically for
+    # NFS filesystems, but rpcbind is only needed for legacy NFSv3/RPC helpers.
+    services.rpcbind.enable = lib.mkOverride 75 false;
 
     host.observability.client = {
       enable = lib.mkDefault (!config.host.isWork);

--- a/nixos/srvarrvm/nfs.nix
+++ b/nixos/srvarrvm/nfs.nix
@@ -59,7 +59,6 @@ let
 in
 {
   boot.supportedFilesystems = [ "nfs" ];
-  services.rpcbind.enable = true;
   systemd.tmpfiles.rules = [
     # Keep the legacy media-root tmpfiles rule in eval for parity with the old
     # stack; the generated tmpfiles file below still filters NFS-managed paths.


### PR DESCRIPTION
- **Restrict beast NFS exports to clients**
- **Disable rpcbind by default**
- **Close UDP NFS port on beast**
