### PR TITLE
NixOS autoUpgrade fixes

### DIFF
--- a/lib/inventory.nix
+++ b/lib/inventory.nix
@@ -28,7 +28,13 @@ let
         (
           { hostname, lib, ... }:
           {
-            system.autoUpgrade.dates = lib.mkIf (lib.hasPrefix "prox-" hostname) "Mon 03:00";
+            system.autoUpgrade = lib.mkIf (lib.hasPrefix "prox-" hostname) {
+              dates = "Mon 03:00";
+              rebootWindow = {
+                lower = lib.mkForce "02:59";
+                upper = lib.mkForce "06:00";
+              };
+            };
           }
         )
       ];

--- a/nixos/_mixins/auto-upgrade/holds.nix
+++ b/nixos/_mixins/auto-upgrade/holds.nix
@@ -16,7 +16,7 @@ let
 
     ${lib.concatMapStringsSep "\n" (hold: ''
       if [[ ! "$today" < "${hold.startDate}" && ! "$today" > "${hold.stopDate}" ]]; then
-        echo "Skipping nixos-upgrade on ${hostname}: ''${today} is within hold ${hold.startDate}..${hold.stopDate}." >&2
+        echo "Skipping NixOS auto-upgrade maintenance on ${hostname}: ''${today} is within hold ${hold.startDate}..${hold.stopDate}." >&2
         exit 1
       fi
     '') cfg.holds}
@@ -87,9 +87,10 @@ in
         }
       ];
       description = ''
-        Inclusive local-date ranges during which `nixos-upgrade.service` should
-        be skipped. Timers still fire on schedule, but the upgrade service exits
-        cleanly before it starts the actual upgrade.
+        Inclusive local-date ranges during which unattended NixOS auto-upgrade
+        maintenance should be skipped. Timers still fire on schedule, but the
+        upgrade service and delayed critical-host reboot service exit cleanly
+        before they perform changes.
       '';
     };
   };
@@ -113,6 +114,9 @@ in
     }
     (lib.mkIf (cfg.holds != [ ]) {
       systemd.services.nixos-upgrade.serviceConfig.ExecCondition = upgradeHoldGuard;
+    })
+    (lib.mkIf (cfg.holds != [ ] && config.host.isCritical && config.system.autoUpgrade.enable) {
+      systemd.services.nixos-weekly-reboot-if-needed.serviceConfig.ExecCondition = upgradeHoldGuard;
     })
     (lib.mkIf metricsCfg.enable {
       # Update immediately on switch so adding or removing a hold changes alert

--- a/nixos/_mixins/auto-upgrade/holds.nix
+++ b/nixos/_mixins/auto-upgrade/holds.nix
@@ -7,6 +7,7 @@
 }:
 let
   cfg = config.host.autoUpgrade;
+  metricsCfg = config.host.observability.nixosUpgrade;
   isoDatePattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$";
   upgradeHoldGuard = pkgs.writeShellScript "nixos-upgrade-hold-guard" ''
     set -euo pipefail
@@ -21,6 +22,41 @@ let
     '') cfg.holds}
 
     exit 0
+  '';
+  writeHoldMetrics = pkgs.writeShellScript "write-nixos-upgrade-hold-metrics" ''
+    set -euo pipefail
+
+    today="$(${pkgs.coreutils}/bin/date +%F)"
+    active=0
+    hold_start=0
+    hold_stop=0
+
+    ${lib.concatMapStringsSep "\n" (hold: ''
+      if [ "$active" -eq 0 ] && [[ ! "$today" < "${hold.startDate}" && ! "$today" > "${hold.stopDate}" ]]; then
+        active=1
+        hold_start="$(${pkgs.coreutils}/bin/date -d "${hold.startDate} 00:00:00" +%s)"
+        hold_stop="$(${pkgs.coreutils}/bin/date -d "${hold.stopDate} 23:59:59" +%s)"
+      fi
+    '') cfg.holds}
+
+    ${pkgs.coreutils}/bin/mkdir -p ${metricsCfg.textfileDir}
+    tmp_file="$(${pkgs.coreutils}/bin/mktemp ${metricsCfg.textfileDir}/nixos-upgrade-hold.prom.XXXXXX)"
+    trap '${pkgs.coreutils}/bin/rm -f "$tmp_file"' EXIT
+
+    cat >"$tmp_file" <<EOF
+    # HELP node_nixos_upgrade_hold_active Whether NixOS auto-upgrade is currently suppressed by a declared hold.
+    # TYPE node_nixos_upgrade_hold_active gauge
+    node_nixos_upgrade_hold_active $active
+    # HELP node_nixos_upgrade_hold_start_time_seconds Unix time for the active NixOS auto-upgrade hold start, or 0 when no hold is active.
+    # TYPE node_nixos_upgrade_hold_start_time_seconds gauge
+    node_nixos_upgrade_hold_start_time_seconds $hold_start
+    # HELP node_nixos_upgrade_hold_stop_time_seconds Unix time for the active NixOS auto-upgrade hold stop, or 0 when no hold is active.
+    # TYPE node_nixos_upgrade_hold_stop_time_seconds gauge
+    node_nixos_upgrade_hold_stop_time_seconds $hold_stop
+    EOF
+
+    ${pkgs.coreutils}/bin/chmod 0644 "$tmp_file"
+    ${pkgs.coreutils}/bin/mv "$tmp_file" ${metricsCfg.textfileDir}/nixos-upgrade-hold.prom
   '';
 in
 {
@@ -58,22 +94,51 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.holds != [ ]) {
-    assertions = lib.concatMap (hold: [
-      {
-        assertion = builtins.match isoDatePattern hold.startDate != null;
-        message = "host.autoUpgrade.holds startDate `${hold.startDate}` must use YYYY-MM-DD.";
-      }
-      {
-        assertion = builtins.match isoDatePattern hold.stopDate != null;
-        message = "host.autoUpgrade.holds stopDate `${hold.stopDate}` must use YYYY-MM-DD.";
-      }
-      {
-        assertion = hold.startDate <= hold.stopDate;
-        message = "host.autoUpgrade.holds range `${hold.startDate}..${hold.stopDate}` must not end before it starts.";
-      }
-    ]) cfg.holds;
+  config = lib.mkMerge [
+    {
+      assertions = lib.concatMap (hold: [
+        {
+          assertion = builtins.match isoDatePattern hold.startDate != null;
+          message = "host.autoUpgrade.holds startDate `${hold.startDate}` must use YYYY-MM-DD.";
+        }
+        {
+          assertion = builtins.match isoDatePattern hold.stopDate != null;
+          message = "host.autoUpgrade.holds stopDate `${hold.stopDate}` must use YYYY-MM-DD.";
+        }
+        {
+          assertion = hold.startDate <= hold.stopDate;
+          message = "host.autoUpgrade.holds range `${hold.startDate}..${hold.stopDate}` must not end before it starts.";
+        }
+      ]) cfg.holds;
+    }
+    (lib.mkIf (cfg.holds != [ ]) {
+      systemd.services.nixos-upgrade.serviceConfig.ExecCondition = upgradeHoldGuard;
+    })
+    (lib.mkIf metricsCfg.enable {
+      # Update immediately on switch so adding or removing a hold changes alert
+      # suppression without waiting for the next hourly timer tick.
+      system.activationScripts.nixosUpgradeHoldMetrics.text = ''
+        ${writeHoldMetrics}
+      '';
 
-    systemd.services.nixos-upgrade.serviceConfig.ExecCondition = upgradeHoldGuard;
-  };
+      systemd.services.nixos-upgrade-hold-metrics = {
+        description = "Write NixOS auto-upgrade hold metrics";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = writeHoldMetrics;
+        };
+      };
+
+      systemd.timers.nixos-upgrade-hold-metrics = {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnBootSec = "5min";
+          OnCalendar = "hourly";
+          Persistent = true;
+          RandomizedDelaySec = "1min";
+          Unit = "nixos-upgrade-hold-metrics.service";
+        };
+      };
+    })
+  ];
 }

--- a/nixos/cachevm/default.nix
+++ b/nixos/cachevm/default.nix
@@ -100,6 +100,10 @@ in
   # ready before machines that may consume it during their own auto-updates.
   system.autoUpgrade.dates = lib.mkForce "Mon 03:30";
   system.autoUpgrade.randomizedDelaySec = lib.mkForce "5min";
+  system.autoUpgrade.rebootWindow = {
+    lower = lib.mkForce "02:59";
+    upper = lib.mkForce "06:00";
+  };
 
   systemd.services.atticd.unitConfig.RequiresMountsFor = "/cache";
 }

--- a/nixos/fanavm/monitoring/prometheus/rules/fleet.rules.yml
+++ b/nixos/fanavm/monitoring/prometheus/rules/fleet.rules.yml
@@ -21,7 +21,10 @@ groups:
           summary: "Root filesystem usage critical on {{ $labels.instance }}"
           description: "The root filesystem on {{ $labels.instance }} has been above 95% used for 15 minutes."
       - alert: HostUpgradeStale
-        expr: ((time() - node_nixos_upgrade_last_success_time_seconds{job=~"node|node-mtls"}) / 86400) > 14
+        expr: |
+          ((time() - node_nixos_upgrade_last_success_time_seconds{job=~"node|node-mtls"}) / 86400) > 14
+            unless on(instance)
+          (node_nixos_upgrade_hold_active{job=~"node|node-mtls"} == 1)
         for: 24h
         labels:
           severity: warning

--- a/nixos/fanavm/monitoring/prometheus/tests/fleet.rules.test.yml
+++ b/nixos/fanavm/monitoring/prometheus/tests/fleet.rules.test.yml
@@ -99,3 +99,13 @@ tests:
             exp_annotations:
               summary: "NixOS upgrades stale on beast"
               description: "beast has not completed a successful NixOS upgrade for more than 14 days."
+
+  - interval: 30s
+    input_series:
+      - series: 'node_nixos_upgrade_last_success_time_seconds{instance="beast",job="node-mtls"}'
+        values: "0x46082"
+      - series: 'node_nixos_upgrade_hold_active{instance="beast",job="node-mtls"}'
+        values: "1x46082"
+    alert_rule_test:
+      - eval_time: 15d30s
+        alertname: HostUpgradeStale

--- a/nixos/upgrade-strategy.md
+++ b/nixos/upgrade-strategy.md
@@ -46,6 +46,10 @@ All times below are in `America/New_York`.
 actual upgrade start time may drift within that window. `frame` still upgrades
 on schedule but does not auto-reboot.
 
+The early Monday builder and cache windows allow auto-reboots from `02:59` until
+`06:00`, so kernel, initrd, or module changes staged during those early windows
+can activate without waiting for manual intervention.
+
 ## Warmup Scope
 
 `fleet-cache-warmer` builds and pushes the CI-validated Nix outputs below:


### PR DESCRIPTION
- **Allow early infra auto-upgrade reboots**
- **Suppress upgrade stale alerts during holds**
- **Hold critical auto-upgrade reboots**
