### PR TITLE
Migration from prox*vm naming, phase 2

### DIFF
--- a/ci-target-inventory.json
+++ b/ci-target-inventory.json
@@ -194,6 +194,21 @@
       "warm": true
     },
     {
+      "attr": "nixosConfigurations.pki.config.system.build.toplevel",
+      "name": "pki (x86_64-linux)",
+      "runner": "ubuntu-latest",
+      "selection": {
+        "hosts": [
+          "pki"
+        ],
+        "prefixes": [
+          "nixos/pkivm/"
+        ]
+      },
+      "system": "x86_64-linux",
+      "warm": true
+    },
+    {
       "attr": "nixosConfigurations.builder1.config.system.build.vm",
       "name": "nixos vm builder1 (x86_64-linux)",
       "runner": "ubuntu-latest",

--- a/common/_mixins/personal-builders/default.nix
+++ b/common/_mixins/personal-builders/default.nix
@@ -9,7 +9,7 @@
 }:
 let
   builderSpec = n: hostInventory.nixosHostSpecsByName."builder${toString n}";
-  toBuilderName = n: hostInventory.toNixosSshHostName (builderSpec n);
+  toBuilderName = n: hostInventory.toNixosShortDnsName (builderSpec n);
 in
 {
   programs.ssh = {

--- a/darwin/mmini/ups.nix
+++ b/darwin/mmini/ups.nix
@@ -72,6 +72,12 @@ in
     esac
   '';
 
+  system.activationScripts.preActivation.text = lib.mkAfter ''
+    if [ -L /etc/nut/upsmon.conf ] && [ ! -e /etc/nut/upsmon.conf ]; then
+      rm /etc/nut/upsmon.conf
+    fi
+  '';
+
   system.activationScripts.postActivation.text = lib.mkAfter ''
     mkdir -p /var/lib/nut
     chmod 700 /var/lib/nut

--- a/home-manager/_mixins/ssh/ticket.nix
+++ b/home-manager/_mixins/ssh/ticket.nix
@@ -36,7 +36,7 @@ let
     spec:
     if hostInventory.isNixosVM spec then
       let
-        sshHost = hostInventory.toNixosSshHostName spec;
+        sshHost = hostInventory.toNixosShortDnsName spec;
       in
       mkTarget {
         name = spec.name;
@@ -67,6 +67,7 @@ let
       value = lib.hm.dag.entryBefore [ "*" ] {
         header = "Host ${lib.concatStringsSep " " patterns}";
         HostName = target.sshHost;
+        HostKeyAlias = target.name;
         User = username;
         IdentitiesOnly = true;
         IdentityFile = ticketKeyPath;

--- a/lib/fleet.nix
+++ b/lib/fleet.nix
@@ -10,7 +10,7 @@ let
   hostInventory = import ../lib/inventory.nix { lib = pkgs.lib; };
   lan = hostInventory.site.lan;
   wgHome = hostInventory.site.wireguard.home;
-  wireguardGatewaySshHost = hostInventory.toNixosSshHostName hostInventory.nixosHostSpecsByName.gw;
+  wireguardGatewaySshHost = hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.gw;
   unifiSyncEnv = import ./unifi-sync-env.nix { inherit hostInventory; };
 
   broadcomSas3flashP15 = pkgs.fetchzip {

--- a/lib/inventory.nix
+++ b/lib/inventory.nix
@@ -10,6 +10,24 @@ let
   frame = "frame";
   nvws = "nvws";
 
+  builderDhcpReservations = {
+    "1" = {
+      match = "bc:24:11:49:bf:fc";
+      hostname = "prox-builder1vm";
+      ip = "192.168.12.106";
+    };
+    "2" = {
+      match = "bc:24:11:dc:ea:2c";
+      hostname = "prox-builder2vm";
+      ip = "192.168.13.243";
+    };
+    "3" = {
+      match = "bc:24:11:2a:ee:d7";
+      hostname = "prox-builder3vm";
+      ip = "192.168.11.114";
+    };
+  };
+
   builderSpec =
     idx:
     let
@@ -19,6 +37,7 @@ let
       isVM = true;
       name = "builder${idx'}";
       proxNode = "prx${idx'}-lab";
+      dhcpReservation = builderDhcpReservations.${idx'};
       stateVersion = "25.11";
       memorySize = 64;
       diskSize = 150;

--- a/lib/inventory.nix
+++ b/lib/inventory.nix
@@ -150,7 +150,7 @@ rec {
         let
           spec = nixosHostSpecsByName.${service.owner};
         in
-        toNixosSshHostName spec;
+        toNixosShortDnsName spec;
     };
 
   site = rec {

--- a/nixos/fanavm/prometheus.nix
+++ b/nixos/fanavm/prometheus.nix
@@ -46,6 +46,7 @@ let
   };
   serviceScrapes = import ./scrapes/services.nix {
     inherit
+      hostInventory
       outputs
       prometheusMtlsTlsConfig
       ;

--- a/nixos/fanavm/scrapes/blackbox.nix
+++ b/nixos/fanavm/scrapes/blackbox.nix
@@ -149,6 +149,8 @@ let
     !(outputs.nixosConfigurations.${name}.config.host.observability.client.blackbox.mtls.enable or false
     )
   ) remoteBlackboxProbeSourceNames;
+  targetHostForNixosName =
+    name: hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.${name};
   mkRemoteBlackboxProbeSourceConfig =
     name:
     let
@@ -156,7 +158,7 @@ let
       mtlsEndpoint = hostConfig.host.observability.client.prometheusMtlsEndpoints.blackbox;
     in
     {
-      exporter = "${hostConfig.host.dnsName}:${toString mtlsEndpoint.port}";
+      exporter = "${targetHostForNixosName name}:${toString mtlsEndpoint.port}";
       scheme = "https";
       source = hostConfig.services.avahi.hostName;
     };

--- a/nixos/fanavm/scrapes/nodes.nix
+++ b/nixos/fanavm/scrapes/nodes.nix
@@ -15,6 +15,8 @@ let
   hostClassForName = name: if isVirtualNodeName name then "virtual" else "hardware";
   scrapeExpectationForHostConfig =
     hostConfig: if hostConfig.host.isLaptop then "intermittent" else "always";
+  targetHostForNixosName =
+    name: hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.${name};
   mkRemoteNixosNodeTargetConfig =
     name:
     let
@@ -29,7 +31,7 @@ let
         instance = name;
         scrape_expectation = scrapeExpectationForHostConfig hostConfig;
       };
-      targets = [ "${hostConfig.host.dnsName}:9100" ];
+      targets = [ "${targetHostForNixosName name}:9100" ];
     };
   nixosNodeExporterTargetNames = builtins.filter (
     name:

--- a/nixos/fanavm/scrapes/proxmox.nix
+++ b/nixos/fanavm/scrapes/proxmox.nix
@@ -12,6 +12,8 @@ let
     && (outputs.nixosConfigurations.${name}.config.host.proxmox.prometheusExporter.enable or false)
   ) nixosConfigNames;
   proxmoxClusterScrapeNodeName = "prx1-lab";
+  targetHostForNixosName =
+    name: hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.${name};
   mkProxmoxPveTargetConfig =
     name:
     let
@@ -24,7 +26,7 @@ let
         proxmox_node = hostConfig.networking.hostName;
         pve_target = hostConfig.host.proxmox.apiCertificate.serverName;
       };
-      targets = [ "${hostConfig.host.dnsName}:${toString endpoint.port}" ];
+      targets = [ "${targetHostForNixosName name}:${toString endpoint.port}" ];
     };
   proxmoxPveTargetConfigs = map mkProxmoxPveTargetConfig proxmoxLabNodeNames;
   proxmoxClusterTargetConfigs = [ (mkProxmoxPveTargetConfig proxmoxClusterScrapeNodeName) ];

--- a/nixos/fanavm/scrapes/services.nix
+++ b/nixos/fanavm/scrapes/services.nix
@@ -1,15 +1,18 @@
 {
+  hostInventory,
   outputs,
   prometheusMtlsTlsConfig,
 }:
 let
   beastHostConfig = outputs.nixosConfigurations.beast.config;
   beastPrometheusEndpoints = beastHostConfig.host.observability.client.prometheusMtlsEndpoints;
+  beastTargetHost = hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.beast;
   lolekEndpoint = beastPrometheusEndpoints.lolek;
   sabnzbdHostConfig = outputs.nixosConfigurations.srvarr.config;
   sabnzbdEndpoint = sabnzbdHostConfig.host.observability.client.prometheusMtlsEndpoints.sabnzbd;
+  sabnzbdTargetHost = hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.srvarr;
   vikunjaHostConfig = outputs.nixosConfigurations.org.config;
-  vikunjaTargetHost = vikunjaHostConfig.host.dnsName;
+  vikunjaTargetHost = hostInventory.toNixosShortDnsName hostInventory.nixosHostSpecsByName.org;
   vikunjaEndpoint = vikunjaHostConfig.host.observability.client.prometheusMtlsEndpoints.vikunja;
 in
 {
@@ -21,7 +24,7 @@ in
       static_configs = [
         {
           targets = [
-            "${beastHostConfig.host.dnsName}:${toString beastPrometheusEndpoints.smartctl.port}"
+            "${beastTargetHost}:${toString beastPrometheusEndpoints.smartctl.port}"
           ];
           labels.instance = "beast";
         }
@@ -35,7 +38,7 @@ in
       static_configs = [
         {
           targets = [
-            "${beastHostConfig.host.dnsName}:${toString beastPrometheusEndpoints.jellyfin.port}"
+            "${beastTargetHost}:${toString beastPrometheusEndpoints.jellyfin.port}"
           ];
           labels.instance = "beast";
         }
@@ -49,7 +52,7 @@ in
       static_configs = [
         {
           targets = [
-            "${beastHostConfig.host.dnsName}:${toString lolekEndpoint.port}"
+            "${beastTargetHost}:${toString lolekEndpoint.port}"
           ];
           labels.instance = "beast";
         }
@@ -62,7 +65,7 @@ in
       static_configs = [
         {
           targets = [
-            "${sabnzbdHostConfig.host.dnsName}:${toString sabnzbdEndpoint.port}"
+            "${sabnzbdTargetHost}:${toString sabnzbdEndpoint.port}"
           ];
           labels.instance = "srvarr";
         }

--- a/pkgs/ssh-ticket/main.py
+++ b/pkgs/ssh-ticket/main.py
@@ -211,7 +211,7 @@ def nix_targets_expr(repo_root):
           spec:
           if inventory.isNixosVM spec then
             let
-              sshHost = inventory.toNixosSshHostName spec;
+              sshHost = inventory.toNixosShortDnsName spec;
             in
             mkTarget {{
               kind = "nixos";

--- a/scripts/_helpers/update-machines-lib.sh
+++ b/scripts/_helpers/update-machines-lib.sh
@@ -36,6 +36,16 @@ resolve_base_host() {
   jq -r --arg h "$host" '.[$h] // $h' <<<"$HOST_BASE_MAP_JSON"
 }
 
+resolve_runtime_host() {
+  local host="$1"
+  if [[ -z "${HOST_RUNTIME_MAP_JSON:-}" ]]; then
+    printf '%s' "$host"
+    return 0
+  fi
+
+  jq -r --arg h "$host" '.[$h] // $h' <<<"$HOST_RUNTIME_MAP_JSON"
+}
+
 resolve_host_alias() {
   local host="$1"
   local resolved

--- a/scripts/update-machines.sh
+++ b/scripts/update-machines.sh
@@ -63,7 +63,7 @@ HOST_BASE_MAP_JSON="$(
           in
           acc
           // {
-            \${configName} = hostInventory.toNixosSshHostName spec;
+            \${configName} = hostInventory.toNixosShortDnsName spec;
           }
         ) { } hostInventory.nixosHostSpecs;
         darwin = builtins.mapAttrs (_: cfg: cfg.hostname) hostInventory.darwinHosts;

--- a/scripts/update-machines.sh
+++ b/scripts/update-machines.sh
@@ -73,6 +73,33 @@ HOST_BASE_MAP_JSON="$(
   )
 )"
 export HOST_BASE_MAP_JSON
+HOST_RUNTIME_MAP_JSON="$(
+  (
+    cd "${REPO_ROOT}"
+    nix eval --impure --json --expr "
+      let
+        hostInventory = import ./lib/inventory.nix {
+          lib = {
+            strings.toUpper = s: s;
+          };
+        };
+        nixos = builtins.foldl' (
+          acc: spec:
+          let
+            configName = hostInventory.toNixosConfigName spec;
+          in
+          acc
+          // {
+            \${configName} = hostInventory.toNixosRuntimeHostName spec;
+          }
+        ) { } hostInventory.nixosHostSpecs;
+        darwin = builtins.mapAttrs (_: cfg: cfg.hostname) hostInventory.darwinHosts;
+      in
+      nixos // darwin
+    "
+  )
+)"
+export HOST_RUNTIME_MAP_JSON
 HOST_ALIAS_MAP_JSON="$(
   (
     cd "${REPO_ROOT}"
@@ -541,7 +568,7 @@ ok_hosts=()
 failed_hosts=()
 for host in "${HOSTS[@]}"; do
   ssh_host="$(resolve_ssh_host "$host")"
-  runtime_host="$(resolve_base_host "$host")"
+  runtime_host="$(resolve_runtime_host "$host")"
   display_host="$(display_host_name "$host")"
   printf '%b\n' "${COLOR_HOST}==> ${display_host}${COLOR_RESET}"
   if ! [ -t 0 ]; then

--- a/tests/test_ssh_ticket.py
+++ b/tests/test_ssh_ticket.py
@@ -101,6 +101,7 @@ def test_target_expression_includes_nixos_and_darwin_configs(tmp_path):
     expr = ssh_ticket.nix_targets_expr(tmp_path)
     assert "inventory.nixosHostSpecs" in expr
     assert "inventory.darwinHosts" in expr
+    assert "sshHost = inventory.toNixosShortDnsName spec;" in expr
     assert "f.nixosConfigurations" not in expr
     assert "f.darwinConfigurations" not in expr
 
@@ -111,8 +112,8 @@ def test_resolve_target_accepts_unique_alias():
             "name": "srvarr",
             "enabled": True,
             "aliases": ["srvarr"],
-            "principal": "ihrachyshka@prox-srvarrvm",
-            "sshHost": "prox-srvarrvm",
+            "principal": "ihrachyshka@srvarr",
+            "sshHost": "srvarr",
         }
     ]
     assert ssh_ticket.resolve_target(targets, "srvarr")["name"] == "srvarr"
@@ -147,7 +148,7 @@ def test_resolve_target_rejects_ambiguous_alias():
 def test_existing_ticket_valid_uses_metadata(tmp_path):
     target = {
         "name": "srvarr",
-        "principal": "ihrachyshka@prox-srvarrvm",
+        "principal": "ihrachyshka@srvarr",
     }
     paths = ssh_ticket.target_paths(target, tmp_path)
     paths["cert"].write_text("not a real cert\n", encoding="utf-8")
@@ -193,9 +194,9 @@ def test_ssht_command_does_not_add_ticket_key_to_agent(tmp_path):
         types.SimpleNamespace(
             key=str(tmp_path / "id_ed25519"), ssh_args=["--", "true"]
         ),
-        {"sshHost": "prox-srvarrvm"},
+        {"sshHost": "srvarr"},
         {"cert": tmp_path / "id_ed25519-cert.pub"},
     )
 
     assert "AddKeysToAgent=no" in cmd
-    assert cmd[-2:] == ["prox-srvarrvm", "true"]
+    assert cmd[-2:] == ["srvarr", "true"]

--- a/tests/update-machines.bats
+++ b/tests/update-machines.bats
@@ -217,6 +217,13 @@ EOF
   [ "$output" = "nvws" ]
 }
 
+@test "resolve_runtime_host can differ from connection host" {
+  export HOST_RUNTIME_MAP_JSON='{"fana":"prox-fanavm"}'
+  run resolve_runtime_host fana
+  [ "$status" -eq 0 ]
+  [ "$output" = "prox-fanavm" ]
+}
+
 @test "resolve_host_alias maps host aliases" {
   export HOST_ALIAS_MAP_JSON='{"org":"org","beast":"beast"}'
   run resolve_host_alias org

--- a/tests/update-machines.bats
+++ b/tests/update-machines.bats
@@ -6,8 +6,9 @@ setup() {
 
 write_update_machines_test_stubs() {
   local stub_dir="$1"
-  local bash_path
+  local bash_path python_path
   bash_path="$(command -v bash)"
+  python_path="$(command -v python3)"
 
   {
     printf '#!%s\n' "$bash_path"
@@ -135,6 +136,7 @@ EOF
 
   {
     printf '#!%s\n' "$bash_path"
+    printf 'python_path=%q\n' "$python_path"
     cat <<'EOF'
 set -euo pipefail
 if [[ "${1-}" == "-q" ]]; then
@@ -145,7 +147,7 @@ if [[ $# -lt 2 ]]; then
   exit 64
 fi
 shift
-python3 - "$@" <<'PY'
+"$python_path" - "$@" <<'PY'
 import os
 import pty
 import subprocess


### PR DESCRIPTION
- **Build pki config in CI**
- **Use short DNS for SSH ticket targets**
- **Use short DNS for update-machine SSH hosts**
- **Use short DNS for personal builders**
- **Use short DNS for WireGuard gateway SSH**
- **Use short DNS for Prometheus scrape targets**
