### PR TITLE
packages: update firefox-devtools-mcp

### DIFF
--- a/pkgs/firefox-devtools-mcp/default.nix
+++ b/pkgs/firefox-devtools-mcp/default.nix
@@ -10,13 +10,13 @@
 
 buildNpmPackage rec {
   pname = "firefox-devtools-mcp";
-  version = "0.9.7";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "firefox-devtools-mcp";
     tag = "v${version}";
-    hash = "sha256-ZaRh98iKbTEPOYdyxnK8o1mU1h6tIwRx1mZW0ozP/KY=";
+    hash = "sha256-JwniY6uXhuW2i7QRVMiWXPZ4POkBMPJ2IYByr1hMxD0=";
   };
 
   nodejs = nodejs_24;


### PR DESCRIPTION
Automated package source update.

Package builds were not run by the updater. Normal CI is expected to validate
whether the updated package still builds or needs follow-up fixes.

| Package | Version | Changelog |
| --- | --- | --- |
| `firefox-devtools-mcp` | `0.9.7 -> 0.9.6` | [link](https://github.com/mozilla/firefox-devtools-mcp/releases/tag/v0.9.6) |

Generated by GitHub Actions.