### PR TITLE
oci-images: update litellm

### DIFF
--- a/lib/oci-images.json
+++ b/lib/oci-images.json
@@ -8,7 +8,7 @@
   "litellm": {
     "changelog": "https://github.com/BerriAI/litellm/releases/tag/{tag}",
     "image": "ghcr.io/berriai/litellm-database",
-    "tag": "v1.90.0",
+    "tag": "v1.90.1",
     "tagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
   },
   "paperless-gpt": {


### PR DESCRIPTION
Automated OCI image tag update.

Container builds were not run by the updater. Normal CI is expected to validate
whether the updated image tag still works with the managed service.

| Target | Image | Tag | Changelog |
| --- | --- | --- | --- |
| `litellm` | `ghcr.io/berriai/litellm-database` | `v1.90.0 -> v1.90.1` | [link](https://github.com/BerriAI/litellm/releases/tag/v1.90.1) |

Generated by GitHub Actions.