### PR TITLE
oci-images: update litellm

### DIFF
--- a/lib/oci-images.json
+++ b/lib/oci-images.json
@@ -9,10 +9,10 @@
   },
   "litellm": {
     "changelog": "https://github.com/BerriAI/litellm/releases/tag/{tag}",
-    "digest": "sha256:fc15e199e743c64beb00ac2cd6ac01e48ba17765ac792188060fa3ede7421ed7",
-    "hash": "sha256-ueYo28D/EIUHFR4ZoocnnXgJFbXtlEfYq3N8qEUzZH8=",
+    "digest": "sha256:9f091622b15c1db6df0cd11491292b4358895da1454a47070dae124d7ae66145",
+    "hash": "sha256-JEmf8tZxMi2e//2pUmfkumT7WXqwIcxja93JX9l8qzw=",
     "image": "ghcr.io/berriai/litellm-database",
-    "tag": "v1.90.1",
+    "tag": "v1.90.3",
     "tagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
   },
   "paperless-gpt": {


### PR DESCRIPTION
Automated OCI image tag update.

OCI images were prefetched for linux/amd64 and pinned as Nix fixed-output
archives. Normal CI is expected to validate whether the updated image still
works with the managed service.

| Target | Image | Tag | Digest | Nix hash | Changelog | Diff |
| --- | --- | --- | --- | --- | --- | --- |
| `litellm` | `ghcr.io/berriai/litellm-database` | `v1.90.1 -> v1.90.3` | `sha256:fc15e199e743c64beb00ac2cd6ac01e48ba17765ac792188060fa3ede7421ed7 -> sha256:9f091622b15c1db6df0cd11491292b4358895da1454a47070dae124d7ae66145` | `sha256-ueYo28D/EIUHFR4ZoocnnXgJFbXtlEfYq3N8qEUzZH8= -> sha256-JEmf8tZxMi2e//2pUmfkumT7WXqwIcxja93JX9l8qzw=` | [link](https://github.com/BerriAI/litellm/releases/tag/v1.90.3) | [compare](https://github.com/BerriAI/litellm/compare/ca6149ab9995707585e50d5255ee6991ed99a52a...2d28d8fadf175587d520239c2ad6a591ffd33d9f) |

Generated by GitHub Actions.