### PR TITLE
packages: update firefox-devtools-mcp

### DIFF
--- a/pkgs/firefox-devtools-mcp/default.nix
+++ b/pkgs/firefox-devtools-mcp/default.nix
@@ -10,13 +10,13 @@
 
 buildNpmPackage rec {
   pname = "firefox-devtools-mcp";
-  version = "0.9.7";
+  version = "0.9.9";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "firefox-devtools-mcp";
     tag = "v${version}";
-    hash = "sha256-ZaRh98iKbTEPOYdyxnK8o1mU1h6tIwRx1mZW0ozP/KY=";
+    hash = "sha256-Bz6LkiUbgu81OnPv6xegmo7EYVgGJdlbB5HZsW4QO/Q=";
   };
 
   nodejs = nodejs_24;


### PR DESCRIPTION
Automated package source update.

Package builds were not run by the updater. Normal CI is expected to validate
whether the updated package still builds or needs follow-up fixes.

| Package | Version | Changelog | Diff |
| --- | --- | --- | --- |
| `firefox-devtools-mcp` | `0.9.7 -> 0.9.9` | [link](https://github.com/mozilla/firefox-devtools-mcp/releases/tag/v0.9.9) | [compare](https://github.com/mozilla/firefox-devtools-mcp/compare/v0.9.7...v0.9.9) |

Generated by GitHub Actions.