### PR TITLE
oci-images: update litellm

### DIFF
--- a/oci/images.json
+++ b/oci/images.json
@@ -9,15 +9,15 @@
   },
   "litellm": {
     "changelog": "https://github.com/BerriAI/litellm/releases/tag/{tag}",
-    "digest": "sha256:9f091622b15c1db6df0cd11491292b4358895da1454a47070dae124d7ae66145",
-    "hash": "sha256-JEmf8tZxMi2e//2pUmfkumT7WXqwIcxja93JX9l8qzw=",
+    "digest": "sha256:6151ddc97c5dc4590740bd14646d78d48267d8b7a1bf398eeaffcd6729b8f0b9",
+    "hash": "sha256-ChVHTW7xaI+UdwmXqtOzAXVKZR/X85BSNGD4Z5gCBhM=",
     "image": "ghcr.io/berriai/litellm-database",
     "signature": {
       "key": "oci/keys/litellm.pub",
       "keyUpstream": "https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub",
       "type": "cosign-key"
     },
-    "tag": "v1.90.3",
+    "tag": "v1.91.0",
     "tagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
   },
   "paperless-gpt": {


### PR DESCRIPTION
Automated OCI image tag update.

OCI images were prefetched for linux/amd64 and pinned as Nix fixed-output
archives. Normal CI is expected to validate whether the updated image still
works with the managed service.

| Target | Image | Tag | Digest | Nix hash | Changelog | Diff | Signature |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `litellm` | `ghcr.io/berriai/litellm-database` | `v1.90.3 -> v1.91.0` | `sha256:9f091622b15c1db6df0cd11491292b4358895da1454a47070dae124d7ae66145 -> sha256:6151ddc97c5dc4590740bd14646d78d48267d8b7a1bf398eeaffcd6729b8f0b9` | `sha256-JEmf8tZxMi2e//2pUmfkumT7WXqwIcxja93JX9l8qzw= -> sha256-ChVHTW7xaI+UdwmXqtOzAXVKZR/X85BSNGD4Z5gCBhM=` | [link](https://github.com/BerriAI/litellm/releases/tag/v1.91.0) | [compare](https://github.com/BerriAI/litellm/compare/2d28d8fadf175587d520239c2ad6a591ffd33d9f...0519dbf25b290dd3a646bf40dc93d40ae36901aa) | `cosign verified` |

Generated by GitHub Actions.