### PR TITLE
oci-images: update paperless-gpt

### DIFF
--- a/nixos/org/paperless.nix
+++ b/nixos/org/paperless.nix
@@ -16,6 +16,8 @@ let
   paperlessStoragePath = "/data/paperless";
   paperlessGptStateDir = "/var/lib/paperless-gpt";
   paperlessGptAutoOcrTag = "paperless-gpt-ocr-auto";
+  paperlessGptContainerUid = "10001";
+  paperlessGptContainerGid = "10001";
   paperlessGptPort = 8080;
   paperlessGptHost = "${paperlessGptService.id}.${hostInventory.site.lan.domain}";
   paperlessGptOauth2ProxyPort = 4181;
@@ -419,10 +421,10 @@ in
     };
     rules = [
       "d '${paperlessGptStateDir}' 0750 root root - -"
-      "d '${paperlessGptStateDir}/config' 0750 root root - -"
-      "d '${paperlessGptStateDir}/hocr' 0750 root root - -"
-      "d '${paperlessGptStateDir}/pdf' 0750 root root - -"
-      "d '${paperlessGptStateDir}/prompts' 0750 root root - -"
+      "d '${paperlessGptStateDir}/config' 0750 ${paperlessGptContainerUid} ${paperlessGptContainerGid} - -"
+      "d '${paperlessGptStateDir}/hocr' 0750 ${paperlessGptContainerUid} ${paperlessGptContainerGid} - -"
+      "d '${paperlessGptStateDir}/pdf' 0750 ${paperlessGptContainerUid} ${paperlessGptContainerGid} - -"
+      "d '${paperlessGptStateDir}/prompts' 0750 ${paperlessGptContainerUid} ${paperlessGptContainerGid} - -"
     ];
   };
 
@@ -510,8 +512,11 @@ in
         AUTO_GENERATE_TAGS = "true";
         AUTO_GENERATE_TITLE = "true";
         AUTO_OCR_TAG = paperlessGptAutoOcrTag;
+        AUTO_TAG_COMPLETE = "paperless-gpt-auto-complete";
         CREATE_LOCAL_HOCR = "false";
         CREATE_LOCAL_PDF = "false";
+        CREATE_NEW_TAGS = "false";
+        FAIL_TAG = "paperless-gpt-failed";
         LLM_LANGUAGE = "English";
         LLM_MODEL = "qwen3.5:9b";
         LLM_PROVIDER = "ollama";
@@ -524,13 +529,16 @@ in
         OCR_PROVIDER = "llm";
         OLLAMA_CONTEXT_LENGTH = "8192";
         OLLAMA_HOST = "http://127.0.0.1:${toString ollamaTunnelPort}";
+        OLLAMA_THINK = "false";
         PAPERLESS_BASE_URL = "http://127.0.0.1:${toString config.services.paperless.port}";
         PAPERLESS_PUBLIC_URL = paperlessService.url;
+        PGID = paperlessGptContainerGid;
         PDF_COPY_METADATA = "true";
         PDF_OCR_TAGGING = "true";
         PDF_REPLACE = "false";
         PDF_SKIP_EXISTING_OCR = "false";
         PDF_UPLOAD = "false";
+        PUID = paperlessGptContainerUid;
         TOKEN_LIMIT = "2000";
         VISION_LLM_MODEL = "qwen3-vl:8b-instruct";
         VISION_LLM_PROVIDER = "ollama";

--- a/oci/images.json
+++ b/oci/images.json
@@ -22,10 +22,10 @@
   },
   "paperless-gpt": {
     "changelog": "https://github.com/icereed/paperless-gpt/releases/tag/{tag}",
-    "digest": "sha256:c0ce6186028911101a2cfe68353f14a9dbb2653596f3f1cff94de4b6db3114ff",
-    "hash": "sha256-QhdJp1l1Le1n6AfPbrmyexcSHaK9ewmJQUFx9fTKcRA=",
+    "digest": "sha256:1210dcf072d9b3de0eb8aff3d7716c28c5d658f2c5b04f0461f16fd6d9551069",
+    "hash": "sha256-qX1kpV9Y+CH9F31tU7flzBUpTSt6T/IeDTJgQVIYH7c=",
     "image": "ghcr.io/icereed/paperless-gpt",
-    "tag": "v0.25.1",
+    "tag": "v0.26.0",
     "tagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
   },
   "romm": {


### PR DESCRIPTION
Automated OCI image tag update.

OCI images were prefetched for linux/amd64 and pinned as Nix fixed-output
archives. Normal CI is expected to validate whether the updated image still
works with the managed service.

| Target | Image | Tag | Digest | Nix hash | Changelog | Diff | Signature |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `paperless-gpt` | `ghcr.io/icereed/paperless-gpt` | `v0.25.1 -> v0.26.0` | `sha256:c0ce6186028911101a2cfe68353f14a9dbb2653596f3f1cff94de4b6db3114ff -> sha256:1210dcf072d9b3de0eb8aff3d7716c28c5d658f2c5b04f0461f16fd6d9551069` | `sha256-QhdJp1l1Le1n6AfPbrmyexcSHaK9ewmJQUFx9fTKcRA= -> sha256-qX1kpV9Y+CH9F31tU7flzBUpTSt6T/IeDTJgQVIYH7c=` | [link](https://github.com/icereed/paperless-gpt/releases/tag/v0.26.0) | [compare](https://github.com/icereed/paperless-gpt/compare/v0.25.1...v0.26.0) | `not configured` |

Generated by GitHub Actions.