### PR TITLE
oci-images: update paperless-gpt

### DIFF
--- a/oci/images.json
+++ b/oci/images.json
@@ -22,10 +22,10 @@
   },
   "paperless-gpt": {
     "changelog": "https://github.com/icereed/paperless-gpt/releases/tag/{tag}",
-    "digest": "sha256:1210dcf072d9b3de0eb8aff3d7716c28c5d658f2c5b04f0461f16fd6d9551069",
-    "hash": "sha256-qX1kpV9Y+CH9F31tU7flzBUpTSt6T/IeDTJgQVIYH7c=",
+    "digest": "sha256:6b9024d1adebfcd6bd7ec5e9da2ca17f9879b1fb5ce749d72905bbb121091ef8",
+    "hash": "sha256-XJeQtA/XtnkbNi8pLFXi4LU24Nxkw7h2vuc1j5HYJkk=",
     "image": "ghcr.io/icereed/paperless-gpt",
-    "tag": "v0.26.0",
+    "tag": "v0.26.1",
     "tagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
   },
   "romm": {


### PR DESCRIPTION
Automated OCI image tag update.

OCI images were prefetched for linux/amd64 and pinned as Nix fixed-output
archives. Normal CI is expected to validate whether the updated image still
works with the managed service.

| Target | Image | Tag | Digest | Nix hash | Changelog | Diff | Signature |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `paperless-gpt` | `ghcr.io/icereed/paperless-gpt` | `v0.26.0 -> v0.26.1` | `sha256:1210dcf072d9b3de0eb8aff3d7716c28c5d658f2c5b04f0461f16fd6d9551069 -> sha256:6b9024d1adebfcd6bd7ec5e9da2ca17f9879b1fb5ce749d72905bbb121091ef8` | `sha256-qX1kpV9Y+CH9F31tU7flzBUpTSt6T/IeDTJgQVIYH7c= -> sha256-XJeQtA/XtnkbNi8pLFXi4LU24Nxkw7h2vuc1j5HYJkk=` | [link](https://github.com/icereed/paperless-gpt/releases/tag/v0.26.1) | [compare](https://github.com/icereed/paperless-gpt/compare/v0.26.0...v0.26.1) | `not configured` |

Generated by GitHub Actions.