### PR TITLE
probe internal endpoints for oauth proxy services

### DIFF
--- a/darwin/_mixins/nix-darwin-backports/default.nix
+++ b/darwin/_mixins/nix-darwin-backports/default.nix
@@ -4,7 +4,7 @@ let
 
   managedUsersWithHomes = lib.filter (
     user: lib.elem user.name cfg.knownUsers && user.name != "root" && user.home != null
-  ) (lib.mapAttrsToList (_: user: user) cfg.users);
+  ) (builtins.attrValues cfg.users);
 
   patchUserHomeCheck =
     user:

--- a/flake.nix
+++ b/flake.nix
@@ -162,18 +162,9 @@
 
     in
     {
-      darwinConfigurations = builtins.listToAttrs (
-        map (
-          name:
-          let
-            cfg = darwinHosts.${name};
-          in
-          {
-            name = name;
-            value = helpers.mkDarwin (cfg // { hostSpecName = name; });
-          }
-        ) (builtins.attrNames darwinHosts)
-      );
+      darwinConfigurations = builtins.mapAttrs (
+        name: cfg: helpers.mkDarwin (cfg // { hostSpecName = name; })
+      ) darwinHosts;
 
       nixosConfigurations = canonicalNixosConfigurations;
 

--- a/lib/inventory.nix
+++ b/lib/inventory.nix
@@ -92,6 +92,7 @@ let
       title ? lib.strings.toSentenceCase id,
       icon ? "sh:${id}",
       blackboxProbe ? true,
+      backendProbe ? null,
       showInGlance ? true,
       glanceCategory ? null,
     }:
@@ -108,6 +109,7 @@ let
         title
         ;
     }
+    // lib.optionalAttrs (backendProbe != null) { inherit backendProbe; }
     // lib.optionalAttrs (publicHost != null) { inherit publicHost; };
 
   assertValidService =
@@ -589,6 +591,7 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/ping";
       glanceCategory = "media-admin";
     }))
     (resolveService (mkService {
@@ -596,6 +599,7 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/ping";
       glanceCategory = "media-admin";
     }))
     (resolveService (mkService {
@@ -603,6 +607,7 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/ping";
       glanceCategory = "media-admin";
     }))
     (resolveService (mkService {
@@ -619,6 +624,7 @@ rec {
       owner = "srvarr";
       publicHost = "mu.${site.public.domain}";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/api/health/live";
       glanceCategory = "user";
     }))
     (resolveService (mkService {
@@ -662,6 +668,7 @@ rec {
       scope = "internal";
       owner = "org";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/api/version";
       glanceCategory = "infrastructure";
     }))
     (resolveService (mkService {
@@ -692,6 +699,7 @@ rec {
       owner = "org";
       publicHost = "search.${site.public.domain}";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/healthz";
       glanceCategory = "user";
     }))
     (resolveService (mkService {
@@ -708,6 +716,7 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/api/system/ping";
       glanceCategory = "media-admin";
     }))
     (resolveService (mkService {
@@ -715,6 +724,7 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/ping";
       glanceCategory = "media-admin";
     }))
     (resolveService (mkService {
@@ -722,6 +732,10 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe = {
+        path = "/__probe/transmission-rpc";
+        blackboxModule = "http_service_409";
+      };
       glanceCategory = "media-admin";
     }))
     (resolveService (mkService {
@@ -731,6 +745,7 @@ rec {
       scope = "internal";
       owner = "srvarr";
       probePath = "/oauth2/sign_in";
+      backendProbe.path = "/__probe/sabnzbd-version";
       glanceCategory = "media-admin";
     }))
   ];

--- a/lib/prometheus-blackbox-modules.nix
+++ b/lib/prometheus-blackbox-modules.nix
@@ -1,3 +1,13 @@
+let
+  httpService = {
+    http = {
+      follow_redirects = true;
+      preferred_ip_protocol = "ip4";
+    };
+    prober = "http";
+    timeout = "5s";
+  };
+in
 {
   dns_udp = {
     dns = {
@@ -11,13 +21,12 @@
     timeout = "5s";
   };
 
-  http_service = {
-    http = {
-      follow_redirects = true;
-      preferred_ip_protocol = "ip4";
+  http_service = httpService;
+
+  http_service_409 = httpService // {
+    http = httpService.http // {
+      valid_status_codes = [ 409 ];
     };
-    prober = "http";
-    timeout = "5s";
   };
 
   icmp_ipv4 = {

--- a/lib/ups-clients.nix
+++ b/lib/ups-clients.nix
@@ -12,10 +12,10 @@ let
     client = hostInventory.toNixosConfigName spec;
   }) (builtins.filter includeClient hostInventory.nixosHostSpecs);
 
-  darwinEntries = lib.mapAttrsToList (_: spec: {
+  darwinEntries = map (spec: {
     server = spec.upsHost;
     client = spec.hostname;
-  }) (lib.filterAttrs (_: includeClient) hostInventory.darwinHosts);
+  }) (builtins.attrValues (lib.filterAttrs (_: includeClient) hostInventory.darwinHosts));
 
   addEntry =
     acc: entry:

--- a/nixos/_mixins/internal-https-service.nix
+++ b/nixos/_mixins/internal-https-service.nix
@@ -111,6 +111,7 @@ let
     // {
       serverName = service.serverName;
       serverAliases = [ ];
+      addSSL = true;
       forceSSL = false;
       # Backend probes live on a separate HTTPS listener instead of the normal
       # service listener. Public ingress proxies to the normal service listener

--- a/nixos/_mixins/internal-https-service.nix
+++ b/nixos/_mixins/internal-https-service.nix
@@ -7,14 +7,115 @@
 let
   cfg = config.host.internalHttps;
   internalPkiRootCaPath = import ../../lib/home-internal-pki-root-ca.nix;
+  # A local alias like `search` is served both as the single-label name and as
+  # mDNS, for example `search` and `search.local`.
   localServerAliasesFor = aliases: aliases ++ builtins.map hostInventory.toLocalDnsName aliases;
   enabledServices = lib.filterAttrs (_: service: service.enable) cfg.services;
-  enabledServerNames = builtins.concatMap (service: [ service.serverName ] ++ service.serverAliases) (
-    builtins.attrValues enabledServices
-  );
+  # All hostnames that consume an nginx server_name on this machine. Example:
+  # the Search service owns `search.home.arpa`, `search`, `search.local`, and
+  # the public sibling vhost `search.ihar.dev`.
+  serviceServerNames =
+    service:
+    [
+      service.serverName
+    ]
+    ++ service.serverAliases
+    ++ service.publicAliases;
+  enabledServerNames = builtins.concatMap serviceServerNames (builtins.attrValues enabledServices);
+  enabledProbeServices = lib.filterAttrs (_: service: service.probe.enable) enabledServices;
+  servicesWithProbePortConflicts = lib.filterAttrs (
+    _: service: service.probe.enable && service.probe.port == service.port
+  ) enabledServices;
   enabledMtlsClients = lib.filterAttrs (_: client: client.enable) cfg.mtlsClients;
   secretAttrName = serviceName: "internal-https-${serviceName}";
   mtlsClientSecretAttrName = clientName: "internal-https-client-${clientName}";
+  # Listener tuple shared by all surfaces for one service. Example: normal
+  # service vhosts listen on :443 while probe-only vhosts listen on :9443.
+  mkListen = service: port: [
+    {
+      addr = service.listenAddress;
+      inherit port;
+      ssl = true;
+    }
+  ];
+  # TLS and optional client-cert verification common to every vhost surface for
+  # a service. Example: `internal-https-search`, `search.ihar.dev`, and
+  # `internal-https-search-probe` reuse the same certificate and mTLS policy.
+  mkTlsVhost = serviceName: service: port: {
+    extraConfig = lib.optionalString service.mtls.enable ''
+      ssl_client_certificate ${service.mtls.trustedCaCertificate};
+      ssl_verify_client on;
+    '';
+    listen = mkListen service port;
+    sslCertificate = config.sops.secrets."${secretAttrName serviceName}-server-crt".path;
+    sslCertificateKey = config.sops.secrets."${secretAttrName serviceName}-server-key".path;
+    sslTrustedCertificate = internalPkiRootCaPath;
+  };
+  # The normal application proxy location for a service. Example: Search maps
+  # `/` to SearXNG, while RomM maps `/api` to its API upstream.
+  mkServiceLocations = service: {
+    ${service.path} = {
+      proxyPass = service.upstream;
+      proxyWebsockets = service.proxyWebsockets;
+      recommendedProxySettings = service.recommendedProxySettings;
+      extraConfig = service.locationExtraConfig;
+    };
+  };
+  # Builds a normal service surface on the service port. It is parameterized so
+  # both the canonical internal host and public sibling hosts share one shape.
+  # Examples: `search.home.arpa` and `search.ihar.dev` both proxy to SearXNG on
+  # :443, but they are separate nginx vhosts.
+  mkProxyVhost =
+    {
+      serviceName,
+      service,
+      serverName,
+      serverAliases ? [ ],
+    }:
+    (mkTlsVhost serviceName service service.port)
+    // {
+      inherit serverName serverAliases;
+      forceSSL = true;
+      locations = mkServiceLocations service;
+    };
+  # Canonical internal service vhost. Example: `internal-https-search` serves
+  # `search.home.arpa` plus internal aliases such as `search` and `search.local`.
+  mkServiceVhost =
+    serviceName: service:
+    mkProxyVhost {
+      inherit serviceName service;
+      inherit (service) serverName serverAliases;
+    };
+  # Public sibling vhost for direct browser-facing names on the service host.
+  # Example: `search.ihar.dev` gets the normal app and OAuth locations, but not
+  # backend probe bypass locations.
+  mkPublicAliasVhost =
+    serviceName: service: publicAlias:
+    mkProxyVhost {
+      inherit serviceName service;
+      serverName = publicAlias;
+    };
+  # Probe-only vhost on the probe port. Example:
+  # `internal-https-search-probe` serves exact backend probe locations on
+  # `https://search.home.arpa:9443/...`; its catch-all returns 404.
+  mkProbeVhost =
+    serviceName: service:
+    (mkTlsVhost serviceName service service.probe.port)
+    // {
+      serverName = service.serverName;
+      serverAliases = [ ];
+      forceSSL = false;
+      # Backend probes live on a separate HTTPS listener instead of the normal
+      # service listener. Public ingress proxies to the normal service listener
+      # using the internal server name, so host alias splitting alone would not
+      # keep auth-bypass health endpoints off the WAN path.
+      locations."/" = {
+        return = "404";
+        extraConfig = ''
+          auth_request off;
+        '';
+      };
+    };
 in
 {
   options.host.internalHttps.localAliases = lib.mkOption {
@@ -103,7 +204,13 @@ in
               serverAliases = lib.mkOption {
                 type = with lib.types; listOf str;
                 default = [ ];
-                description = "Additional hostnames served by the internal HTTPS vhost.";
+                description = "Additional internal hostnames served by the canonical internal HTTPS vhost.";
+              };
+
+              publicAliases = lib.mkOption {
+                type = with lib.types; listOf str;
+                default = [ ];
+                description = "Browser-facing hostnames served by sibling HTTPS vhosts with the same upstream and certificate.";
               };
 
               sans = lib.mkOption {
@@ -114,6 +221,7 @@ in
                     config.serverName
                   ]
                   ++ config.serverAliases
+                  ++ config.publicAliases
                 );
                 description = "DNS SANs to include when issuing this service certificate.";
               };
@@ -186,6 +294,16 @@ in
                   description = "CA certificate bundle trusted for inbound client certificate verification.";
                 };
               };
+
+              probe = {
+                enable = lib.mkEnableOption "probe-only internal HTTPS listener";
+
+                port = lib.mkOption {
+                  type = port;
+                  default = 9443;
+                  description = "HTTPS port for exact backend probe locations; no catch-all upstream is exposed on this listener.";
+                };
+              };
             };
           }
         )
@@ -203,7 +321,11 @@ in
       {
         assertion =
           (builtins.length enabledServerNames) == (builtins.length (lib.unique enabledServerNames));
-        message = "host.internalHttps.services must not reuse the same serverName on one host.";
+        message = "host.internalHttps.services must not reuse the same serverName, serverAlias, or publicAlias on one host.";
+      }
+      {
+        assertion = servicesWithProbePortConflicts == { };
+        message = "host.internalHttps.services probe listeners must use a port distinct from the normal service port. Offenders: ${lib.concatStringsSep ", " (builtins.attrNames servicesWithProbePortConflicts)}";
       }
     ];
 
@@ -253,34 +375,26 @@ in
       enable = true;
       recommendedProxySettings = true;
       recommendedTlsSettings = true;
-      virtualHosts = lib.mapAttrs' (
-        serviceName: service:
-        lib.nameValuePair "internal-https-${serviceName}" {
-          serverName = service.serverName;
-          serverAliases = service.serverAliases;
-          forceSSL = true;
-          extraConfig = lib.optionalString service.mtls.enable ''
-            ssl_client_certificate ${service.mtls.trustedCaCertificate};
-            ssl_verify_client on;
-          '';
-          listen = [
-            {
-              addr = service.listenAddress;
-              port = service.port;
-              ssl = true;
-            }
-          ];
-          sslCertificate = config.sops.secrets."${secretAttrName serviceName}-server-crt".path;
-          sslCertificateKey = config.sops.secrets."${secretAttrName serviceName}-server-key".path;
-          sslTrustedCertificate = internalPkiRootCaPath;
-          locations.${service.path} = {
-            proxyPass = service.upstream;
-            proxyWebsockets = service.proxyWebsockets;
-            recommendedProxySettings = service.recommendedProxySettings;
-            extraConfig = service.locationExtraConfig;
-          };
-        }
-      ) enabledServices;
+      virtualHosts =
+        lib.mapAttrs' (
+          serviceName: service:
+          lib.nameValuePair "internal-https-${serviceName}" (mkServiceVhost serviceName service)
+        ) enabledServices
+        // builtins.listToAttrs (
+          builtins.concatLists (
+            lib.mapAttrsToList (
+              serviceName: service:
+              map (publicAlias: {
+                name = publicAlias;
+                value = mkPublicAliasVhost serviceName service publicAlias;
+              }) service.publicAliases
+            ) enabledServices
+          )
+        )
+        // lib.mapAttrs' (
+          serviceName: service:
+          lib.nameValuePair "internal-https-${serviceName}-probe" (mkProbeVhost serviceName service)
+        ) enabledProbeServices;
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf (enabledServices != { }) (
@@ -290,6 +404,9 @@ in
           lib.optionals service.openFirewall [
             80
             service.port
+          ]
+          ++ lib.optionals (service.openFirewall && service.probe.enable) [
+            service.probe.port
           ]
         ) (builtins.attrValues enabledServices)
       )

--- a/nixos/_mixins/internal-https-service.nix
+++ b/nixos/_mixins/internal-https-service.nix
@@ -95,6 +95,13 @@ let
       inherit serviceName service;
       serverName = publicAlias;
     };
+  # Every public alias gets a sibling vhost keyed by that public hostname.
+  # Example: `search.ihar.dev = mkPublicAliasVhost "search" search ...`.
+  mkPublicAliasVhostsFor =
+    serviceName: service:
+    lib.genAttrs service.publicAliases (
+      publicAlias: mkPublicAliasVhost serviceName service publicAlias
+    );
   # Probe-only vhost on the probe port. Example:
   # `internal-https-search-probe` serves exact backend probe locations on
   # `https://search.home.arpa:9443/...`; its catch-all returns 404.
@@ -380,17 +387,7 @@ in
           serviceName: service:
           lib.nameValuePair "internal-https-${serviceName}" (mkServiceVhost serviceName service)
         ) enabledServices
-        // builtins.listToAttrs (
-          builtins.concatLists (
-            lib.mapAttrsToList (
-              serviceName: service:
-              map (publicAlias: {
-                name = publicAlias;
-                value = mkPublicAliasVhost serviceName service publicAlias;
-              }) service.publicAliases
-            ) enabledServices
-          )
-        )
+        // lib.concatMapAttrs mkPublicAliasVhostsFor enabledServices
         // lib.mapAttrs' (
           serviceName: service:
           lib.nameValuePair "internal-https-${serviceName}-probe" (mkProbeVhost serviceName service)

--- a/nixos/_mixins/sso-oauth2-proxy-gate-probes.nix
+++ b/nixos/_mixins/sso-oauth2-proxy-gate-probes.nix
@@ -1,0 +1,80 @@
+{ lib }:
+let
+  # Internal service names that request exact backend probe locations. Example:
+  # the Search gate has `probeLocationsByName.search."= /healthz"`.
+  serviceNamesFor = gate: builtins.attrNames gate.probeLocationsByName;
+
+  # Probe location sets must be non-empty so enabling a probe listener always
+  # exposes at least one intentional backend check. Example offender:
+  # `probeLocationsByName.search = { };`.
+  emptyServiceNamesFor =
+    gate:
+    builtins.filter (serviceName: gate.probeLocationsByName.${serviceName} == { }) (
+      serviceNamesFor gate
+    );
+
+  # Flatten probe location keys so assertions can reject broad auth bypasses.
+  # Example: `search:= /healthz` is allowed; `search:/healthz` is not because
+  # it would be a prefix location rather than one exact backend probe URL.
+  locationEntriesFor =
+    gate:
+    builtins.concatMap (
+      serviceName:
+      map (locationName: {
+        inherit locationName serviceName;
+        label = "${serviceName}:${locationName}";
+      }) (builtins.attrNames gate.probeLocationsByName.${serviceName})
+    ) (serviceNamesFor gate);
+
+  # Probe bypass locations must be exact nginx matches so we never accidentally
+  # expose an unauthenticated subtree. Example offender: `search:/healthz`.
+  unsafeLocationNamesFor =
+    gate:
+    map (entry: entry.label) (
+      builtins.filter (entry: !(lib.hasPrefix "= /" entry.locationName)) (locationEntriesFor gate)
+    );
+
+  # Probe-only vhost name created by internal-https-service. Example: `search`
+  # maps to `internal-https-search-probe`.
+  vhostNameFor = serviceName: "internal-https-${serviceName}-probe";
+in
+{
+  # Enable the probe listener only for services with explicit probe locations.
+  # Example: a Search health URL turns on `host.internalHttps.services.search.probe`.
+  enableAttrsFor =
+    gate:
+    lib.genAttrs (serviceNamesFor gate) (_: {
+      probe.enable = true;
+    });
+
+  assertionsFor =
+    gateName: gate:
+    let
+      unknownProbeServices = builtins.filter (
+        serviceName: !(builtins.elem serviceName gate.internalHttpsServiceNames)
+      ) (serviceNamesFor gate);
+    in
+    [
+      {
+        assertion = unknownProbeServices == [ ];
+        message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName must only reference internalHttpsServiceNames.";
+      }
+      {
+        assertion = unsafeLocationNamesFor gate == [ ];
+        message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName must use exact nginx locations like '= /healthz'. Offenders: ${lib.concatStringsSep ", " (unsafeLocationNamesFor gate)}";
+      }
+      {
+        assertion = emptyServiceNamesFor gate == [ ];
+        message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName entries must not be empty. Offenders: ${lib.concatStringsSep ", " (emptyServiceNamesFor gate)}";
+      }
+    ];
+
+  # Probe vhosts get only their explicit probe locations, not the normal app
+  # proxy or OAuth endpoints. Example: `internal-https-search-probe` gets
+  # `= /healthz` and the probe-vhost catch-all remains 404.
+  vhostsFor =
+    gate:
+    lib.mapAttrs' (
+      serviceName: locations: lib.nameValuePair (vhostNameFor serviceName) { inherit locations; }
+    ) gate.probeLocationsByName;
+}

--- a/nixos/_mixins/sso-oauth2-proxy-gate.nix
+++ b/nixos/_mixins/sso-oauth2-proxy-gate.nix
@@ -8,6 +8,7 @@
 let
   cfg = config.host.sso.oauth2ProxyGates;
   oidc = import ../../lib/oidc-clients.nix { inherit lib hostInventory; };
+  probeHelpers = import ./sso-oauth2-proxy-gate-probes.nix { inherit lib; };
 
   gateSubmodule =
     gateName:
@@ -303,31 +304,6 @@ let
   locationsFor =
     gate: name:
     (oauth2ProxyLocations gate) // gate.extraLocations // (gate.extraLocationsByName.${name} or { });
-  # Internal services with exact backend probe locations. Example: the Search
-  # gate has `probeLocationsByName.search."= /healthz"`.
-  probeServiceNamesFor = gate: builtins.attrNames gate.probeLocationsByName;
-  emptyProbeServiceNamesFor =
-    gate:
-    builtins.filter (serviceName: gate.probeLocationsByName.${serviceName} == { }) (
-      probeServiceNamesFor gate
-    );
-  # Flatten probe location keys so assertions can reject broad auth bypasses.
-  # Example: `search:= /healthz` is allowed; `search:/healthz` is not because
-  # it would be a prefix location rather than one exact backend probe URL.
-  probeLocationEntriesFor =
-    gate:
-    builtins.concatMap (
-      serviceName:
-      map (locationName: {
-        inherit locationName serviceName;
-        label = "${serviceName}:${locationName}";
-      }) (builtins.attrNames gate.probeLocationsByName.${serviceName})
-    ) (probeServiceNamesFor gate);
-  unsafeProbeLocationNamesFor =
-    gate:
-    map (entry: entry.label) (
-      builtins.filter (entry: !(lib.hasPrefix "= /" entry.locationName)) (probeLocationEntriesFor gate)
-    );
   # Normal service surfaces that should receive OAuth locations. Example:
   # `search` expands to `internal-https-search` and `search.ihar.dev`.
   internalServiceVhostNames =
@@ -339,9 +315,6 @@ let
       "internal-https-${serviceName}"
     ]
     ++ service.publicAliases;
-  # Probe-only surface for exact unauthenticated backend checks. Example:
-  # `search` maps to `internal-https-search-probe`.
-  probeVhostNameFor = serviceName: "internal-https-${serviceName}-probe";
   # OAuth-protected internal HTTPS vhosts. Example: this installs `/oauth2/`,
   # `= /oauth2/auth`, and protected app locations on `internal-https-search`
   # and on its public sibling `search.ihar.dev`.
@@ -356,14 +329,6 @@ let
         }) (internalServiceVhostNames serviceName)
       ) gate.internalHttpsServiceNames
     );
-  # Probe vhosts get only their explicit probe locations, not the normal app
-  # proxy or OAuth endpoints. Example: `internal-https-search-probe` gets
-  # `= /healthz` and the probe-vhost catch-all remains 404.
-  probeVhostsFor =
-    gate:
-    lib.mapAttrs' (
-      serviceName: locations: lib.nameValuePair (probeVhostNameFor serviceName) { inherit locations; }
-    ) gate.probeLocationsByName;
   # Public vhosts owned by host.externalService instead of host.internalHttps.
   # Example: Beast's Aurral gate protects the external `au.ihar.dev` vhost.
   protectedExternalVhostsFor =
@@ -385,34 +350,20 @@ in
   config = lib.mkIf (enabledGates != { }) {
     assertions =
       builtins.concatLists (
-        lib.mapAttrsToList (gateName: gate: [
-          {
-            assertion = gate.allowedGroups != [ ];
-            message = "host.sso.oauth2ProxyGates.${gateName}.allowedGroups must not be empty.";
-          }
-          {
-            assertion = gate.whitelistDomains != [ ];
-            message = "host.sso.oauth2ProxyGates.${gateName}.whitelistDomains must not be empty.";
-          }
-          {
-            assertion =
-              let
-                unknownProbeServices = builtins.filter (
-                  serviceName: !(builtins.elem serviceName gate.internalHttpsServiceNames)
-                ) (probeServiceNamesFor gate);
-              in
-              unknownProbeServices == [ ];
-            message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName must only reference internalHttpsServiceNames.";
-          }
-          {
-            assertion = unsafeProbeLocationNamesFor gate == [ ];
-            message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName must use exact nginx locations like '= /healthz'. Offenders: ${lib.concatStringsSep ", " (unsafeProbeLocationNamesFor gate)}";
-          }
-          {
-            assertion = emptyProbeServiceNamesFor gate == [ ];
-            message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName entries must not be empty. Offenders: ${lib.concatStringsSep ", " (emptyProbeServiceNamesFor gate)}";
-          }
-        ]) enabledGates
+        lib.mapAttrsToList (
+          gateName: gate:
+          [
+            {
+              assertion = gate.allowedGroups != [ ];
+              message = "host.sso.oauth2ProxyGates.${gateName}.allowedGroups must not be empty.";
+            }
+            {
+              assertion = gate.whitelistDomains != [ ];
+              message = "host.sso.oauth2ProxyGates.${gateName}.whitelistDomains must not be empty.";
+            }
+          ]
+          ++ probeHelpers.assertionsFor gateName gate
+        ) enabledGates
       )
       ++ [
         {
@@ -487,9 +438,7 @@ in
           # of the normal service vhost. Public ingress forwards to the internal
           # service name, so attaching these locations to :443 would expose them
           # through browser-facing hostnames such as search.ihar.dev.
-          (lib.genAttrs (probeServiceNamesFor gate) (_: {
-            probe.enable = true;
-          }))
+          (probeHelpers.enableAttrsFor gate)
         ]) enabledGates
       )
     );
@@ -505,7 +454,8 @@ in
 
     services.nginx.virtualHosts = lib.mkMerge (
       lib.mapAttrsToList (
-        _: gate: protectedInternalVhostsFor gate // probeVhostsFor gate // protectedExternalVhostsFor gate
+        _: gate:
+        protectedInternalVhostsFor gate // probeHelpers.vhostsFor gate // protectedExternalVhostsFor gate
       ) enabledGates
     );
 

--- a/nixos/_mixins/sso-oauth2-proxy-gate.nix
+++ b/nixos/_mixins/sso-oauth2-proxy-gate.nix
@@ -333,12 +333,9 @@ let
   # Example: Beast's Aurral gate protects the external `au.ihar.dev` vhost.
   protectedExternalVhostsFor =
     gate:
-    builtins.listToAttrs (
-      map (hostName: {
-        name = hostName;
-        value.locations = locationsFor gate hostName;
-      }) gate.externalHostNames
-    );
+    lib.genAttrs gate.externalHostNames (hostName: {
+      locations = locationsFor gate hostName;
+    });
 in
 {
   options.host.sso.oauth2ProxyGates = lib.mkOption {
@@ -430,7 +427,7 @@ in
 
     host.internalHttps.services = lib.mkMerge (
       builtins.concatLists (
-        lib.mapAttrsToList (_: gate: [
+        map (gate: [
           (lib.genAttrs gate.internalHttpsServiceNames (_: {
             locationExtraConfig = authRequestLocationConfig gate;
           }))
@@ -439,17 +436,17 @@ in
           # service name, so attaching these locations to :443 would expose them
           # through browser-facing hostnames such as search.ihar.dev.
           (probeHelpers.enableAttrsFor gate)
-        ]) enabledGates
+        ]) (builtins.attrValues enabledGates)
       )
     );
 
     host.externalService.virtualHosts = lib.mkMerge (
-      lib.mapAttrsToList (
-        _: gate:
+      map (
+        gate:
         lib.genAttrs gate.externalHostNames (_: {
           locationExtraConfig = authRequestLocationConfig gate;
         })
-      ) enabledGates
+      ) (builtins.attrValues enabledGates)
     );
 
     services.nginx.virtualHosts = lib.mkMerge (

--- a/nixos/_mixins/sso-oauth2-proxy-gate.nix
+++ b/nixos/_mixins/sso-oauth2-proxy-gate.nix
@@ -193,6 +193,12 @@ let
           default = { };
           description = "Extra nginx locations added to one protected internal service or external hostname.";
         };
+
+        probeLocationsByName = lib.mkOption {
+          type = with lib.types; attrsOf (attrsOf anything);
+          default = { };
+          description = "Extra nginx locations added only to one protected internal service's probe-only HTTPS listener.";
+        };
       };
     };
 
@@ -297,6 +303,77 @@ let
   locationsFor =
     gate: name:
     (oauth2ProxyLocations gate) // gate.extraLocations // (gate.extraLocationsByName.${name} or { });
+  # Internal services with exact backend probe locations. Example: the Search
+  # gate has `probeLocationsByName.search."= /healthz"`.
+  probeServiceNamesFor = gate: builtins.attrNames gate.probeLocationsByName;
+  emptyProbeServiceNamesFor =
+    gate:
+    builtins.filter (serviceName: gate.probeLocationsByName.${serviceName} == { }) (
+      probeServiceNamesFor gate
+    );
+  # Flatten probe location keys so assertions can reject broad auth bypasses.
+  # Example: `search:= /healthz` is allowed; `search:/healthz` is not because
+  # it would be a prefix location rather than one exact backend probe URL.
+  probeLocationEntriesFor =
+    gate:
+    builtins.concatMap (
+      serviceName:
+      map (locationName: {
+        inherit locationName serviceName;
+        label = "${serviceName}:${locationName}";
+      }) (builtins.attrNames gate.probeLocationsByName.${serviceName})
+    ) (probeServiceNamesFor gate);
+  unsafeProbeLocationNamesFor =
+    gate:
+    map (entry: entry.label) (
+      builtins.filter (entry: !(lib.hasPrefix "= /" entry.locationName)) (probeLocationEntriesFor gate)
+    );
+  # Normal service surfaces that should receive OAuth locations. Example:
+  # `search` expands to `internal-https-search` and `search.ihar.dev`.
+  internalServiceVhostNames =
+    serviceName:
+    let
+      service = config.host.internalHttps.services.${serviceName};
+    in
+    [
+      "internal-https-${serviceName}"
+    ]
+    ++ service.publicAliases;
+  # Probe-only surface for exact unauthenticated backend checks. Example:
+  # `search` maps to `internal-https-search-probe`.
+  probeVhostNameFor = serviceName: "internal-https-${serviceName}-probe";
+  # OAuth-protected internal HTTPS vhosts. Example: this installs `/oauth2/`,
+  # `= /oauth2/auth`, and protected app locations on `internal-https-search`
+  # and on its public sibling `search.ihar.dev`.
+  protectedInternalVhostsFor =
+    gate:
+    builtins.listToAttrs (
+      builtins.concatMap (
+        serviceName:
+        map (vhostName: {
+          name = vhostName;
+          value.locations = locationsFor gate serviceName;
+        }) (internalServiceVhostNames serviceName)
+      ) gate.internalHttpsServiceNames
+    );
+  # Probe vhosts get only their explicit probe locations, not the normal app
+  # proxy or OAuth endpoints. Example: `internal-https-search-probe` gets
+  # `= /healthz` and the probe-vhost catch-all remains 404.
+  probeVhostsFor =
+    gate:
+    lib.mapAttrs' (
+      serviceName: locations: lib.nameValuePair (probeVhostNameFor serviceName) { inherit locations; }
+    ) gate.probeLocationsByName;
+  # Public vhosts owned by host.externalService instead of host.internalHttps.
+  # Example: Beast's Aurral gate protects the external `au.ihar.dev` vhost.
+  protectedExternalVhostsFor =
+    gate:
+    builtins.listToAttrs (
+      map (hostName: {
+        name = hostName;
+        value.locations = locationsFor gate hostName;
+      }) gate.externalHostNames
+    );
 in
 {
   options.host.sso.oauth2ProxyGates = lib.mkOption {
@@ -316,6 +393,24 @@ in
           {
             assertion = gate.whitelistDomains != [ ];
             message = "host.sso.oauth2ProxyGates.${gateName}.whitelistDomains must not be empty.";
+          }
+          {
+            assertion =
+              let
+                unknownProbeServices = builtins.filter (
+                  serviceName: !(builtins.elem serviceName gate.internalHttpsServiceNames)
+                ) (probeServiceNamesFor gate);
+              in
+              unknownProbeServices == [ ];
+            message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName must only reference internalHttpsServiceNames.";
+          }
+          {
+            assertion = unsafeProbeLocationNamesFor gate == [ ];
+            message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName must use exact nginx locations like '= /healthz'. Offenders: ${lib.concatStringsSep ", " (unsafeProbeLocationNamesFor gate)}";
+          }
+          {
+            assertion = emptyProbeServiceNamesFor gate == [ ];
+            message = "host.sso.oauth2ProxyGates.${gateName}.probeLocationsByName entries must not be empty. Offenders: ${lib.concatStringsSep ", " (emptyProbeServiceNamesFor gate)}";
           }
         ]) enabledGates
       )
@@ -383,12 +478,20 @@ in
       ) enabledGates;
 
     host.internalHttps.services = lib.mkMerge (
-      lib.mapAttrsToList (
-        _: gate:
-        lib.genAttrs gate.internalHttpsServiceNames (_: {
-          locationExtraConfig = authRequestLocationConfig gate;
-        })
-      ) enabledGates
+      builtins.concatLists (
+        lib.mapAttrsToList (_: gate: [
+          (lib.genAttrs gate.internalHttpsServiceNames (_: {
+            locationExtraConfig = authRequestLocationConfig gate;
+          }))
+          # Backend probe bypasses intentionally use a separate listener instead
+          # of the normal service vhost. Public ingress forwards to the internal
+          # service name, so attaching these locations to :443 would expose them
+          # through browser-facing hostnames such as search.ihar.dev.
+          (lib.genAttrs (probeServiceNamesFor gate) (_: {
+            probe.enable = true;
+          }))
+        ]) enabledGates
+      )
     );
 
     host.externalService.virtualHosts = lib.mkMerge (
@@ -402,19 +505,7 @@ in
 
     services.nginx.virtualHosts = lib.mkMerge (
       lib.mapAttrsToList (
-        _: gate:
-        builtins.listToAttrs (
-          map (serviceName: {
-            name = "internal-https-${serviceName}";
-            value.locations = locationsFor gate serviceName;
-          }) gate.internalHttpsServiceNames
-        )
-        // builtins.listToAttrs (
-          map (hostName: {
-            name = hostName;
-            value.locations = locationsFor gate hostName;
-          }) gate.externalHostNames
-        )
+        _: gate: protectedInternalVhostsFor gate // probeVhostsFor gate // protectedExternalVhostsFor gate
       ) enabledGates
     );
 

--- a/nixos/beast/backup-server.nix
+++ b/nixos/beast/backup-server.nix
@@ -213,17 +213,13 @@ in
     })
   ];
 
-  systemd.tmpfiles.rules = builtins.concatLists (
-    map (
-      name:
-      let
-        owner = if name == "beast" then cloudOffloadUser else mkBackupUser name;
-      in
-      [
-        "d ${mkBackupRepo name} 0750 ${owner} ${owner} - -"
-      ]
-    ) (builtins.attrNames backupClients)
-  );
+  systemd.tmpfiles.rules = map (
+    name:
+    let
+      owner = if name == "beast" then cloudOffloadUser else mkBackupUser name;
+    in
+    "d ${mkBackupRepo name} 0750 ${owner} ${owner} - -"
+  ) (builtins.attrNames backupClients);
 
   sops = {
     secrets =

--- a/nixos/beast/jellarr.nix
+++ b/nixos/beast/jellarr.nix
@@ -85,11 +85,8 @@ in
   ];
 
   sops = {
-    secrets = builtins.listToAttrs (
-      map (user: {
-        name = mkJellyfinUserPasswordSecret user.name;
-        value = jellyfinSecretFile;
-      }) userDefinitions
+    secrets = lib.genAttrs (map (user: mkJellyfinUserPasswordSecret user.name) userDefinitions) (
+      _: jellyfinSecretFile
     );
     templates."jellarr.env" = {
       inherit (jellyfinSecretFile) owner group mode;

--- a/nixos/beast/nginx.nix
+++ b/nixos/beast/nginx.nix
@@ -7,70 +7,25 @@
 let
   arrVmAddress = hostInventory.toNixosHostIpv4Address "srvarr";
   orgVmAddress = hostInventory.toNixosHostIpv4Address "org";
-  backendMtlsServices = builtins.listToAttrs (
-    map
-      (
-        { id, localPort }:
-        {
-          name = id;
-          value = {
-            clientName = id;
-            serverName = "${id}.${hostInventory.site.lan.domain}";
-            inherit localPort;
-          };
-        }
-      )
-      [
-        {
-          id = "id";
-          localPort = 18443;
-        }
-        {
-          id = "dash";
-          localPort = 18081;
-        }
-        {
-          id = "seerr";
-          localPort = 15055;
-        }
-        {
-          id = "romm";
-          localPort = 18080;
-        }
-        {
-          id = "aurral";
-          localPort = 13001;
-        }
-        {
-          id = "audiobookshelf";
-          localPort = 19292;
-        }
-        {
-          id = "shelfmark";
-          localPort = 18084;
-        }
-        {
-          id = "vikunja";
-          localPort = 13456;
-        }
-        {
-          id = "paperless";
-          localPort = 12881;
-        }
-        {
-          id = "llm";
-          localPort = 14000;
-        }
-        {
-          id = "ai";
-          localPort = 14001;
-        }
-        {
-          id = "search";
-          localPort = 18083;
-        }
-      ]
-  );
+  backendMtlsServicePorts = {
+    id = 18443;
+    dash = 18081;
+    seerr = 15055;
+    romm = 18080;
+    aurral = 13001;
+    audiobookshelf = 19292;
+    shelfmark = 18084;
+    vikunja = 13456;
+    paperless = 12881;
+    llm = 14000;
+    ai = 14001;
+    search = 18083;
+  };
+  backendMtlsServices = builtins.mapAttrs (id: localPort: {
+    clientName = id;
+    serverName = "${id}.${hostInventory.site.lan.domain}";
+    inherit localPort;
+  }) backendMtlsServicePorts;
   publicServiceBackendAddresses = {
     beast = "127.0.0.1";
     srvarr = arrVmAddress;

--- a/nixos/fana/monitoring/prometheus/rules/service-probes.rules.yml
+++ b/nixos/fana/monitoring/prometheus/rules/service-probes.rules.yml
@@ -20,6 +20,15 @@ groups:
         annotations:
           summary: "Public WAN service probe scrape down"
           description: "Prometheus has been unable to scrape any blackbox-public-wan probe targets for 5 minutes."
+      - alert: BlackboxBackendScrapeDown
+        expr: max by(job) (up{job="blackbox-backend"}) < 1
+        for: 5m
+        labels:
+          severity: warning
+          category: observability
+        annotations:
+          summary: "Backend service probe scrape down"
+          description: "Prometheus has been unable to scrape any blackbox-backend probe targets for 5 minutes."
       - alert: PublicServiceProbeDown
         expr: probe_success{job="blackbox-arr",scope="external"} < 1
         for: 5m
@@ -47,3 +56,12 @@ groups:
         annotations:
           summary: "Internal service probe down: {{ $labels.service_title }}"
           description: "The internal blackbox probe for {{ $labels.service_title }} ({{ $labels.target }}) has been failing for 5 minutes."
+      - alert: BackendServiceProbeDown
+        expr: probe_success{job="blackbox-backend"} < 1
+        for: 5m
+        labels:
+          severity: warning
+          category: service
+        annotations:
+          summary: "Backend service probe down: {{ $labels.service_title }}"
+          description: "The backend blackbox probe for {{ $labels.service_title }} ({{ $labels.target }}) has been failing for 5 minutes."

--- a/nixos/fana/monitoring/prometheus/tests/service-probes.rules.test.yml
+++ b/nixos/fana/monitoring/prometheus/tests/service-probes.rules.test.yml
@@ -60,6 +60,27 @@ tests:
 
   - interval: 30s
     input_series:
+      - series: 'up{job="blackbox-backend",instance="paperless-gpt"}'
+        values: "0x10 1x2"
+    alert_rule_test:
+      - eval_time: 4m30s
+        alertname: BlackboxBackendScrapeDown
+      - eval_time: 5m
+        alertname: BlackboxBackendScrapeDown
+        exp_alerts:
+          - exp_labels:
+              alertname: BlackboxBackendScrapeDown
+              category: observability
+              job: blackbox-backend
+              severity: warning
+            exp_annotations:
+              summary: "Backend service probe scrape down"
+              description: "Prometheus has been unable to scrape any blackbox-backend probe targets for 5 minutes."
+      - eval_time: 5m30s
+        alertname: BlackboxBackendScrapeDown
+
+  - interval: 30s
+    input_series:
       - series: 'probe_success{job="blackbox-arr",instance="jellyfin",scope="external"}'
         values: "1x12"
     alert_rule_test:
@@ -177,3 +198,37 @@ tests:
             exp_annotations:
               summary: "Internal service probe down: Proxmox prx1-lab"
               description: "The internal blackbox probe for Proxmox prx1-lab (https://prx1-lab/) has been failing for 5 minutes."
+
+  - interval: 30s
+    input_series:
+      - series: 'probe_success{job="blackbox-backend",instance="paperless-gpt",scope="backend",service="paperless-gpt",service_title="Paperless GPT",backend_probe="http",backend_probe_title="Backend HTTP",target="https://paperless-gpt.home.arpa/api/version"}'
+        values: "1x12"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: BackendServiceProbeDown
+
+  - interval: 30s
+    input_series:
+      - series: 'probe_success{job="blackbox-backend",instance="paperless-gpt",scope="backend",service="paperless-gpt",service_title="Paperless GPT",backend_probe="http",backend_probe_title="Backend HTTP",target="https://paperless-gpt.home.arpa/api/version"}'
+        values: "0x10 1x2"
+    alert_rule_test:
+      - eval_time: 4m30s
+        alertname: BackendServiceProbeDown
+      - eval_time: 5m
+        alertname: BackendServiceProbeDown
+        exp_alerts:
+          - exp_labels:
+              alertname: BackendServiceProbeDown
+              backend_probe: http
+              backend_probe_title: Backend HTTP
+              category: service
+              instance: paperless-gpt
+              job: blackbox-backend
+              scope: backend
+              service: paperless-gpt
+              service_title: Paperless GPT
+              severity: warning
+              target: https://paperless-gpt.home.arpa/api/version
+            exp_annotations:
+              summary: "Backend service probe down: Paperless GPT"
+              description: "The backend blackbox probe for Paperless GPT (https://paperless-gpt.home.arpa/api/version) has been failing for 5 minutes."

--- a/nixos/fana/monitoring/prometheus/tests/service-probes.rules.test.yml
+++ b/nixos/fana/monitoring/prometheus/tests/service-probes.rules.test.yml
@@ -201,7 +201,7 @@ tests:
 
   - interval: 30s
     input_series:
-      - series: 'probe_success{job="blackbox-backend",instance="paperless-gpt",scope="backend",service="paperless-gpt",service_title="Paperless GPT",backend_probe="http",backend_probe_title="Backend HTTP",target="https://paperless-gpt.home.arpa/api/version"}'
+      - series: 'probe_success{job="blackbox-backend",instance="paperless-gpt",scope="backend",service="paperless-gpt",service_title="Paperless GPT",backend_probe="http",backend_probe_title="Backend HTTP",target="https://paperless-gpt.home.arpa:9443/api/version"}'
         values: "1x12"
     alert_rule_test:
       - eval_time: 5m
@@ -209,7 +209,7 @@ tests:
 
   - interval: 30s
     input_series:
-      - series: 'probe_success{job="blackbox-backend",instance="paperless-gpt",scope="backend",service="paperless-gpt",service_title="Paperless GPT",backend_probe="http",backend_probe_title="Backend HTTP",target="https://paperless-gpt.home.arpa/api/version"}'
+      - series: 'probe_success{job="blackbox-backend",instance="paperless-gpt",scope="backend",service="paperless-gpt",service_title="Paperless GPT",backend_probe="http",backend_probe_title="Backend HTTP",target="https://paperless-gpt.home.arpa:9443/api/version"}'
         values: "0x10 1x2"
     alert_rule_test:
       - eval_time: 4m30s
@@ -228,7 +228,7 @@ tests:
               service: paperless-gpt
               service_title: Paperless GPT
               severity: warning
-              target: https://paperless-gpt.home.arpa/api/version
+              target: https://paperless-gpt.home.arpa:9443/api/version
             exp_annotations:
               summary: "Backend service probe down: Paperless GPT"
-              description: "The backend blackbox probe for Paperless GPT (https://paperless-gpt.home.arpa/api/version) has been failing for 5 minutes."
+              description: "The backend blackbox probe for Paperless GPT (https://paperless-gpt.home.arpa:9443/api/version) has been failing for 5 minutes."

--- a/nixos/fana/scrapes/blackbox.nix
+++ b/nixos/fana/scrapes/blackbox.nix
@@ -51,15 +51,23 @@ let
       builtins.getAttr service.id httpsServices
     else
       null;
+  # Builds the target URL for a service owned by another NixOS host. Normal
+  # OAuth/front-door probes use :443, for example
+  # `https://search.home.arpa/oauth2/sign_in`; backend probes use the
+  # probe-only listener, for example `https://search.home.arpa:9443/healthz`,
+  # so auth-bypass checks stay off the public gateway's :443 upstream path.
   mkOwnerServiceProbe =
-    service: probePath:
+    service: probePath: useProbeListener:
     let
       httpsService = httpsServiceFor service;
+      probePortSuffix = lib.optionalString (
+        useProbeListener && httpsService.probe.port != 443
+      ) ":${toString httpsService.probe.port}";
     in
     if httpsService != null then
       {
         blackboxModule = if httpsService.mtls.enable then "http_service_mtls" else "http_service";
-        probeUrl = "https://${httpsService.serverName}${probePath}";
+        probeUrl = "https://${httpsService.serverName}${probePortSuffix}${probePath}";
         url = "https://${httpsService.serverName}/";
       }
     else if service.owner == "fana" then
@@ -79,12 +87,12 @@ let
     if service.scope == "external" then
       service
     else
-      service // (mkOwnerServiceProbe service service.probePath)
+      service // (mkOwnerServiceProbe service service.probePath false)
   ) hostInventory.blackboxServices;
   backendProbeCatalog = map (
     service:
     let
-      ownerProbe = mkOwnerServiceProbe service service.backendProbe.path;
+      ownerProbe = mkOwnerServiceProbe service service.backendProbe.path true;
     in
     service
     // ownerProbe

--- a/nixos/fana/scrapes/blackbox.nix
+++ b/nixos/fana/scrapes/blackbox.nix
@@ -51,38 +51,57 @@ let
       builtins.getAttr service.id httpsServices
     else
       null;
-  inventoryServiceCatalog = map (
-    service:
+  mkOwnerServiceProbe =
+    service: probePath:
     let
       httpsService = httpsServiceFor service;
     in
-    if service.scope == "external" then
-      service
-    else if httpsService != null then
-      service
-      // {
+    if httpsService != null then
+      {
         blackboxModule = if httpsService.mtls.enable then "http_service_mtls" else "http_service";
-        probeUrl = "https://${httpsService.serverName}${service.probePath}";
+        probeUrl = "https://${httpsService.serverName}${probePath}";
         url = "https://${httpsService.serverName}/";
       }
     else if service.owner == "fana" then
-      service
-      // {
-        probeUrl = "http://127.0.0.1:${toString grafanaPort}/${service.probePath}";
+      {
+        probeUrl = "http://127.0.0.1:${toString grafanaPort}/${probePath}";
         url = "http://${service.displayHost}:3000/";
       }
     else if service.owner == "srvarr" then
-      service
-      // {
-        probeUrl = "http://${service.probeHost}:${toString (srvarrPortFor service.id)}${service.probePath}";
+      {
+        probeUrl = "http://${service.probeHost}:${toString (srvarrPortFor service.id)}${probePath}";
         url = "http://${service.displayHost}:${toString (srvarrPortFor service.id)}/";
       }
     else
-      throw "Blackbox service ${service.id} must expose enabled internal HTTPS"
+      throw "Blackbox service ${service.id} must expose enabled internal HTTPS";
+  inventoryServiceCatalog = map (
+    service:
+    if service.scope == "external" then
+      service
+    else
+      service // (mkOwnerServiceProbe service service.probePath)
   ) hostInventory.blackboxServices;
-  usesHttpMtls = builtins.any (
-    service: (service.blackboxModule or null) == "http_service_mtls"
-  ) inventoryServiceCatalog;
+  backendProbeCatalog = map (
+    service:
+    let
+      ownerProbe = mkOwnerServiceProbe service service.backendProbe.path;
+    in
+    service
+    // ownerProbe
+    // {
+      blackboxModule =
+        if service.backendProbe ? blackboxModule then
+          service.backendProbe.blackboxModule
+        else
+          ownerProbe.blackboxModule or "http_service";
+      backend_probe = service.backendProbe.name or "http";
+      backend_probe_title = service.backendProbe.title or "Backend HTTP";
+      scope = "backend";
+    }
+  ) (builtins.filter (service: service ? backendProbe) hostInventory.blackboxServices);
+  usesHttpMtls = builtins.any (service: (service.blackboxModule or null) == "http_service_mtls") (
+    inventoryServiceCatalog ++ backendProbeCatalog
+  );
   proxmoxLabNodeNames = builtins.filter (
     name:
     (outputs.nixosConfigurations.${name}.config.host.isProxmox or false)
@@ -263,6 +282,21 @@ let
       targets = [ resolver.target ];
     }) publicServiceCatalog
   ) publicDnsProbeTargets;
+  mkServiceHttpStaticConfig = service: {
+    labels = {
+      module = service.blackboxModule or "http_service";
+      scope = service.scope;
+      service = service.id;
+      service_title = service.title;
+    }
+    // lib.optionalAttrs (service ? tlsRotation) {
+      tls_rotation = service.tlsRotation;
+    }
+    // lib.optionalAttrs (service ? backend_probe) {
+      inherit (service) backend_probe backend_probe_title;
+    };
+    targets = [ service.probeUrl ];
+  };
   blackboxProbeRelabelConfigs = [
     {
       source_labels = [ "__address__" ];
@@ -316,18 +350,38 @@ in
     {
       job_name = "blackbox-arr";
       metrics_path = "/probe";
-      static_configs = map (service: {
-        labels = {
-          module = service.blackboxModule or "http_service";
-          scope = service.scope;
-          service = service.id;
-          service_title = service.title;
+      static_configs = map mkServiceHttpStaticConfig serviceCatalog;
+      relabel_configs = [
+        {
+          source_labels = [ "module" ];
+          target_label = "__param_module";
         }
-        // lib.optionalAttrs (service ? tlsRotation) {
-          tls_rotation = service.tlsRotation;
-        };
-        targets = [ service.probeUrl ];
-      }) serviceCatalog;
+        {
+          source_labels = [ "__address__" ];
+          target_label = "__param_target";
+        }
+        {
+          source_labels = [ "__param_target" ];
+          target_label = "target";
+        }
+        {
+          source_labels = [ "service" ];
+          target_label = "instance";
+        }
+        {
+          replacement = "127.0.0.1:${toString config.services.prometheus.exporters.blackbox.port}";
+          target_label = "__address__";
+        }
+        {
+          action = "labeldrop";
+          regex = "module";
+        }
+      ];
+    }
+    {
+      job_name = "blackbox-backend";
+      metrics_path = "/probe";
+      static_configs = map mkServiceHttpStaticConfig backendProbeCatalog;
       relabel_configs = [
         {
           source_labels = [ "module" ];

--- a/nixos/fana/scrapes/blackbox.nix
+++ b/nixos/fana/scrapes/blackbox.nix
@@ -98,17 +98,15 @@ let
     // ownerProbe
     // {
       blackboxModule =
-        if service.backendProbe ? blackboxModule then
-          service.backendProbe.blackboxModule
-        else
-          ownerProbe.blackboxModule or "http_service";
+        service.backendProbe.blackboxModule or (ownerProbe.blackboxModule or "http_service");
       backend_probe = service.backendProbe.name or "http";
       backend_probe_title = service.backendProbe.title or "Backend HTTP";
       scope = "backend";
     }
   ) (builtins.filter (service: service ? backendProbe) hostInventory.blackboxServices);
+  serviceHttpProbeCatalog = inventoryServiceCatalog ++ backendProbeCatalog;
   usesHttpMtls = builtins.any (service: (service.blackboxModule or null) == "http_service_mtls") (
-    inventoryServiceCatalog ++ backendProbeCatalog
+    serviceHttpProbeCatalog
   );
   proxmoxLabNodeNames = builtins.filter (
     name:
@@ -305,6 +303,38 @@ let
     };
     targets = [ service.probeUrl ];
   };
+  serviceHttpRelabelConfigs = [
+    {
+      source_labels = [ "module" ];
+      target_label = "__param_module";
+    }
+    {
+      source_labels = [ "__address__" ];
+      target_label = "__param_target";
+    }
+    {
+      source_labels = [ "__param_target" ];
+      target_label = "target";
+    }
+    {
+      source_labels = [ "service" ];
+      target_label = "instance";
+    }
+    {
+      replacement = "127.0.0.1:${toString config.services.prometheus.exporters.blackbox.port}";
+      target_label = "__address__";
+    }
+    {
+      action = "labeldrop";
+      regex = "module";
+    }
+  ];
+  mkServiceHttpScrapeConfig = jobName: catalog: {
+    job_name = jobName;
+    metrics_path = "/probe";
+    static_configs = map mkServiceHttpStaticConfig catalog;
+    relabel_configs = serviceHttpRelabelConfigs;
+  };
   blackboxProbeRelabelConfigs = [
     {
       source_labels = [ "__address__" ];
@@ -355,68 +385,8 @@ in
   };
 
   scrapeConfigs = [
-    {
-      job_name = "blackbox-arr";
-      metrics_path = "/probe";
-      static_configs = map mkServiceHttpStaticConfig serviceCatalog;
-      relabel_configs = [
-        {
-          source_labels = [ "module" ];
-          target_label = "__param_module";
-        }
-        {
-          source_labels = [ "__address__" ];
-          target_label = "__param_target";
-        }
-        {
-          source_labels = [ "__param_target" ];
-          target_label = "target";
-        }
-        {
-          source_labels = [ "service" ];
-          target_label = "instance";
-        }
-        {
-          replacement = "127.0.0.1:${toString config.services.prometheus.exporters.blackbox.port}";
-          target_label = "__address__";
-        }
-        {
-          action = "labeldrop";
-          regex = "module";
-        }
-      ];
-    }
-    {
-      job_name = "blackbox-backend";
-      metrics_path = "/probe";
-      static_configs = map mkServiceHttpStaticConfig backendProbeCatalog;
-      relabel_configs = [
-        {
-          source_labels = [ "module" ];
-          target_label = "__param_module";
-        }
-        {
-          source_labels = [ "__address__" ];
-          target_label = "__param_target";
-        }
-        {
-          source_labels = [ "__param_target" ];
-          target_label = "target";
-        }
-        {
-          source_labels = [ "service" ];
-          target_label = "instance";
-        }
-        {
-          replacement = "127.0.0.1:${toString config.services.prometheus.exporters.blackbox.port}";
-          target_label = "__address__";
-        }
-        {
-          action = "labeldrop";
-          regex = "module";
-        }
-      ];
-    }
+    (mkServiceHttpScrapeConfig "blackbox-arr" serviceCatalog)
+    (mkServiceHttpScrapeConfig "blackbox-backend" backendProbeCatalog)
     {
       job_name = "blackbox-public-wan";
       metrics_path = "/probe";

--- a/nixos/org/ai.nix
+++ b/nixos/org/ai.nix
@@ -150,7 +150,7 @@ in
   host.internalHttps.services.ai = {
     enable = true;
     upstream = "http://127.0.0.1:${toString openWebuiPort}";
-    serverAliases = [ aiService.publicHost ];
+    publicAliases = [ aiService.publicHost ];
     mtls.enable = true;
     locationExtraConfig = ''
       client_max_body_size 128m;

--- a/nixos/org/default.nix
+++ b/nixos/org/default.nix
@@ -89,7 +89,7 @@ in
   host.internalHttps.services.vikunja = {
     enable = true;
     upstream = "http://127.0.0.1:${toString vikunjaPort}";
-    serverAliases = [ vikunjaService.publicHost ];
+    publicAliases = [ vikunjaService.publicHost ];
     mtls.enable = true;
   };
 

--- a/nixos/org/llm.nix
+++ b/nixos/org/llm.nix
@@ -272,7 +272,7 @@ in
   host.internalHttps.services.llm = {
     enable = true;
     upstream = "http://127.0.0.1:${toString litellmPort}";
-    serverAliases = [ llmService.publicHost ];
+    publicAliases = [ llmService.publicHost ];
     mtls.enable = true;
     locationExtraConfig = ''
       if ($uri = /metrics) {

--- a/nixos/org/paperless.nix
+++ b/nixos/org/paperless.nix
@@ -451,6 +451,13 @@ in
     internalHttpsServiceNames = [ "paperless-gpt" ];
     signInLocationName = "@paperless_gpt_oauth2_proxy_sign_in";
     authCookieVariableName = "paperless_gpt_auth_cookie";
+    extraLocations."= /api/version" = {
+      proxyPass = "http://127.0.0.1:${toString paperlessGptPort}";
+      recommendedProxySettings = true;
+      extraConfig = ''
+        auth_request off;
+      '';
+    };
   };
 
   host.observability.client.prometheusMtlsEndpoints.paperless = {

--- a/nixos/org/paperless.nix
+++ b/nixos/org/paperless.nix
@@ -419,7 +419,7 @@ in
   host.internalHttps.services.paperless = {
     enable = true;
     upstream = "http://127.0.0.1:${toString config.services.paperless.port}";
-    serverAliases = [ paperlessService.publicHost ];
+    publicAliases = [ paperlessService.publicHost ];
     mtls.enable = true;
     recommendedProxySettings = false;
     locationExtraConfig = ''
@@ -451,7 +451,7 @@ in
     internalHttpsServiceNames = [ "paperless-gpt" ];
     signInLocationName = "@paperless_gpt_oauth2_proxy_sign_in";
     authCookieVariableName = "paperless_gpt_auth_cookie";
-    extraLocations."= /api/version" = {
+    probeLocationsByName.paperless-gpt."= /api/version" = {
       proxyPass = "http://127.0.0.1:${toString paperlessGptPort}";
       recommendedProxySettings = true;
       extraConfig = ''

--- a/nixos/org/searxng.nix
+++ b/nixos/org/searxng.nix
@@ -206,6 +206,13 @@ in
         auth_request off;
       '';
     };
+    extraLocations."= /healthz" = {
+      proxyPass = "http://127.0.0.1:${toString searxPort}";
+      recommendedProxySettings = true;
+      extraConfig = ''
+        auth_request off;
+      '';
+    };
   };
 
   host.internalHttps.services.search = {

--- a/nixos/org/searxng.nix
+++ b/nixos/org/searxng.nix
@@ -206,7 +206,7 @@ in
         auth_request off;
       '';
     };
-    extraLocations."= /healthz" = {
+    probeLocationsByName.search."= /healthz" = {
       proxyPass = "http://127.0.0.1:${toString searxPort}";
       recommendedProxySettings = true;
       extraConfig = ''
@@ -218,7 +218,7 @@ in
   host.internalHttps.services.search = {
     enable = true;
     upstream = "http://127.0.0.1:${toString searxPort}";
-    serverAliases = [ searchService.publicHost ];
+    publicAliases = [ searchService.publicHost ];
     mtls.enable = true;
   };
 

--- a/nixos/pki/id.nix
+++ b/nixos/pki/id.nix
@@ -152,7 +152,7 @@ in
   host.internalHttps.services.id = {
     enable = true;
     upstream = "https://127.0.0.1:${toString kanidmPort}";
-    serverAliases = [ idService.publicHost ];
+    publicAliases = [ idService.publicHost ];
     mtls.enable = true;
     locationExtraConfig = ''
       proxy_set_header Host ${idService.publicHost};

--- a/nixos/srvarr/audiobookshelf.nix
+++ b/nixos/srvarr/audiobookshelf.nix
@@ -118,7 +118,7 @@ in
   host.internalHttps.services.audiobookshelf = {
     enable = true;
     upstream = "http://127.0.0.1:${toString port}";
-    serverAliases = [ audiobookshelfService.publicHost ];
+    publicAliases = [ audiobookshelfService.publicHost ];
     mtls.enable = true;
     recommendedProxySettings = false;
     locationExtraConfig = ''

--- a/nixos/srvarr/aurral.nix
+++ b/nixos/srvarr/aurral.nix
@@ -102,7 +102,7 @@ in
   host.internalHttps.services.aurral = {
     enable = true;
     upstream = "http://127.0.0.1:${toString aurralPort}";
-    serverAliases = [ aurralService.publicHost ];
+    publicAliases = [ aurralService.publicHost ];
     mtls.enable = true;
   };
 }

--- a/nixos/srvarr/aurral.nix
+++ b/nixos/srvarr/aurral.nix
@@ -104,5 +104,17 @@ in
     upstream = "http://127.0.0.1:${toString aurralPort}";
     publicAliases = [ aurralService.publicHost ];
     mtls.enable = true;
+    probe.enable = true;
+  };
+
+  # Aurral's OAuth gate lives on beast because only the public hostname is
+  # browser-protected. The backend probe still needs a probe-only listener on
+  # the service owner, so define this exact health location locally on srvarr.
+  services.nginx.virtualHosts."internal-https-aurral-probe".locations."= /api/health/live" = {
+    proxyPass = "http://127.0.0.1:${toString aurralPort}";
+    recommendedProxySettings = true;
+    extraConfig = ''
+      auth_request off;
+    '';
   };
 }

--- a/nixos/srvarr/glance.nix
+++ b/nixos/srvarr/glance.nix
@@ -179,7 +179,7 @@ in
     glance = {
       enable = true;
       upstream = "http://127.0.0.1:${toString glanceInternalPort}";
-      serverAliases = [ dashService.publicHost ];
+      publicAliases = [ dashService.publicHost ];
     };
 
     dash = {

--- a/nixos/srvarr/oauth2-proxy.nix
+++ b/nixos/srvarr/oauth2-proxy.nix
@@ -1,4 +1,9 @@
-{ hostInventory, lib, ... }:
+{
+  config,
+  hostInventory,
+  lib,
+  ...
+}:
 let
   clientId = "srvarr-admin-apps";
   oauth2ProxyCookieName = "_srvarr_admin_sso";
@@ -6,6 +11,43 @@ let
   protectedServiceHosts = lib.unique (
     lib.concatMap hostInventory.toInternalHttpsServiceHosts protectedServiceIds
   );
+  backendPorts = {
+    bazarr = config.services.bazarr.listenPort;
+    lidarr = config.services.lidarr.settings.server.port;
+    prowlarr = config.services.prowlarr.settings.server.port;
+    radarr = config.services.radarr.settings.server.port;
+    sabnzbd = config.services.sabnzbd.settings.misc.port;
+    sonarr = config.services.sonarr.settings.server.port;
+    transmission = config.services.transmission.settings.rpc-port;
+  };
+  mkBackendProbeLocation =
+    {
+      port,
+      upstreamPath ? null,
+      recommendedProxySettings ? true,
+      extraConfig ? "",
+    }:
+    {
+      proxyPass = "http://127.0.0.1:${toString port}${
+        lib.optionalString (upstreamPath != null) upstreamPath
+      }";
+      inherit recommendedProxySettings;
+      extraConfig = ''
+        auth_request off;
+      ''
+      + extraConfig;
+    };
+  mkBackendProbePathLocation = serviceName: path: {
+    ${path} = mkBackendProbeLocation {
+      port = backendPorts.${serviceName};
+    };
+  };
+  servarrPingProbeLocations = lib.genAttrs [
+    "lidarr"
+    "prowlarr"
+    "radarr"
+    "sonarr"
+  ] (serviceName: mkBackendProbePathLocation serviceName "= /ping");
   # Bazarr has no reverse-proxy auth mode here: its config has `auth.type: null`,
   # but the UI still calls `POST /api/system/account` on logout. Bazarr returns
   # 500 for that state because its logout endpoint only accepts `form` or
@@ -22,6 +64,32 @@ let
         add_header Set-Cookie "${oauth2ProxyCookieName}_1=; Path=/; Max-Age=0; HttpOnly; Secure" always;
         add_header Set-Cookie "${oauth2ProxyCookieName}_2=; Path=/; Max-Age=0; HttpOnly; Secure" always;
         add_header Set-Cookie "${oauth2ProxyCookieName}_csrf=; Path=/; Max-Age=0; HttpOnly; Secure" always;
+      '';
+    };
+  };
+  backendProbeLocations = servarrPingProbeLocations // {
+    bazarr = mkBackendProbePathLocation "bazarr" "= /api/system/ping";
+    sabnzbd."= /__probe/sabnzbd-version" = mkBackendProbeLocation {
+      port = backendPorts.sabnzbd;
+      upstreamPath = "/api?mode=version&output=json";
+    };
+    transmission."= /__probe/transmission-rpc" = mkBackendProbeLocation {
+      port = backendPorts.transmission;
+      upstreamPath = "/transmission/rpc";
+      recommendedProxySettings = false;
+      # Transmission's RPC host whitelist expects the upstream hop to use the
+      # local host name; this probe alias is method-limited so the auth bypass
+      # can observe the RPC endpoint's CSRF 409 without exposing RPC actions.
+      extraConfig = ''
+        limit_except GET {
+          deny all;
+        }
+        proxy_set_header Host ${config.networking.hostName};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $hostname;
       '';
     };
   };
@@ -50,6 +118,8 @@ in
         proxyHeader = "X-Email";
       }
     ];
-    extraLocationsByName.bazarr = bazarrLogoutLocations;
+    extraLocationsByName = backendProbeLocations // {
+      bazarr = backendProbeLocations.bazarr // bazarrLogoutLocations;
+    };
   };
 }

--- a/nixos/srvarr/oauth2-proxy.nix
+++ b/nixos/srvarr/oauth2-proxy.nix
@@ -20,6 +20,14 @@ let
     sonarr = config.services.sonarr.settings.server.port;
     transmission = config.services.transmission.settings.rpc-port;
   };
+  localBackendProxyHeaders = ''
+    proxy_set_header Host ${config.networking.hostName};
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Server $hostname;
+  '';
   mkBackendProbeLocation =
     {
       port,
@@ -72,6 +80,11 @@ let
     sabnzbd."= /__probe/sabnzbd-version" = mkBackendProbeLocation {
       port = backendPorts.sabnzbd;
       upstreamPath = "/api?mode=version&output=json";
+      recommendedProxySettings = false;
+      # SABnzbd rejects arbitrary Host headers even for the version API. Use
+      # the local machine name accepted by its hostname check while still
+      # exposing only this exact unauthenticated probe URL.
+      extraConfig = localBackendProxyHeaders;
     };
     transmission."= /__probe/transmission-rpc" = mkBackendProbeLocation {
       port = backendPorts.transmission;
@@ -84,13 +97,8 @@ let
         limit_except GET {
           deny all;
         }
-        proxy_set_header Host ${config.networking.hostName};
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Server $hostname;
-      '';
+      ''
+      + localBackendProxyHeaders;
     };
   };
 in

--- a/nixos/srvarr/oauth2-proxy.nix
+++ b/nixos/srvarr/oauth2-proxy.nix
@@ -67,7 +67,7 @@ let
       '';
     };
   };
-  backendProbeLocations = servarrPingProbeLocations // {
+  backendProbeLocationsByName = servarrPingProbeLocations // {
     bazarr = mkBackendProbePathLocation "bazarr" "= /api/system/ping";
     sabnzbd."= /__probe/sabnzbd-version" = mkBackendProbeLocation {
       port = backendPorts.sabnzbd;
@@ -118,8 +118,7 @@ in
         proxyHeader = "X-Email";
       }
     ];
-    extraLocationsByName = backendProbeLocations // {
-      bazarr = backendProbeLocations.bazarr // bazarrLogoutLocations;
-    };
+    extraLocationsByName.bazarr = bazarrLogoutLocations;
+    probeLocationsByName = backendProbeLocationsByName;
   };
 }

--- a/nixos/srvarr/romm.nix
+++ b/nixos/srvarr/romm.nix
@@ -573,7 +573,7 @@ in
     enable = true;
     upstream = "http://127.0.0.1:${toString apiPort}";
     path = "/api";
-    serverAliases = [ rommService.publicHost ];
+    publicAliases = [ rommService.publicHost ];
     mtls.enable = true;
   };
 }

--- a/nixos/srvarr/seerr.nix
+++ b/nixos/srvarr/seerr.nix
@@ -39,7 +39,7 @@ in
   host.internalHttps.services.seerr = {
     enable = true;
     upstream = "http://127.0.0.1:${toString config.services.seerr.port}";
-    serverAliases = [ seerrService.publicHost ];
+    publicAliases = [ seerrService.publicHost ];
     mtls.enable = true;
   };
 }

--- a/nixos/srvarr/shelfmark.nix
+++ b/nixos/srvarr/shelfmark.nix
@@ -81,7 +81,7 @@ in
   host.internalHttps.services.shelfmark = {
     enable = true;
     upstream = "http://127.0.0.1:${toString config.services.shelfmark.environment.FLASK_PORT}";
-    serverAliases = [ shelfmarkService.publicHost ];
+    publicAliases = [ shelfmarkService.publicHost ];
     mtls.enable = true;
     recommendedProxySettings = false;
     locationExtraConfig = ''


### PR DESCRIPTION
- **Add backend blackbox probes**
- **Keep backend probes on internal listener**
- **Extract oauth probe helpers**
- **Simplify backend probe wiring**
- **Simplify Nix attr transformations**
