### PR TITLE
oci-images: update litellm

### DIFF
--- a/oci/images.json
+++ b/oci/images.json
@@ -9,15 +9,15 @@
   },
   "litellm": {
     "changelog": "https://github.com/BerriAI/litellm/releases/tag/{tag}",
-    "digest": "sha256:a0952ba673e930ff6fcf4c78e291a7fe60ce0f9cd0d0d0f5a1fe6fa3d0624c89",
-    "hash": "sha256-m8ppy2YI1jqd7t6oCCL962Ws20WUWhnFgujXjsPUGJM=",
+    "digest": "sha256:64696cd89e425c2b2d0e0c78cece7d52430185ef155a5b0a67557ab9a226af9b",
+    "hash": "sha256-PUHVmVbMHOuSo32FynMHgraCCuGmB1WlDaC2CZOMyB4=",
     "image": "ghcr.io/berriai/litellm-database",
     "signature": {
       "key": "oci/keys/litellm.pub",
       "keyUpstream": "https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub",
       "type": "cosign-key"
     },
-    "tag": "v1.91.1",
+    "tag": "v1.91.2",
     "tagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
   },
   "paperless-gpt": {


### PR DESCRIPTION
Automated OCI image tag update.

OCI images were prefetched for linux/amd64 and pinned as Nix fixed-output
archives. Normal CI is expected to validate whether the updated image still
works with the managed service.

| Target | Image | Tag | Digest | Nix hash | Changelog | Diff | Signature |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `litellm` | `ghcr.io/berriai/litellm-database` | `v1.91.1 -> v1.91.2` | `sha256:a0952ba673e930ff6fcf4c78e291a7fe60ce0f9cd0d0d0f5a1fe6fa3d0624c89 -> sha256:64696cd89e425c2b2d0e0c78cece7d52430185ef155a5b0a67557ab9a226af9b` | `sha256-m8ppy2YI1jqd7t6oCCL962Ws20WUWhnFgujXjsPUGJM= -> sha256-PUHVmVbMHOuSo32FynMHgraCCuGmB1WlDaC2CZOMyB4=` | [link](https://github.com/BerriAI/litellm/releases/tag/v1.91.2) | [compare](https://github.com/BerriAI/litellm/compare/cdc8c72c97a8a22938211674d6815cd59607a483...6950a52a151e606a5e535170d2c9f6bf263593cf) | `cosign verified` |

Generated by GitHub Actions.