### PR TITLE
packages: update nico-cli

### DIFF
--- a/home-manager/_mixins/nv/pkgs/nico-cli/default.nix
+++ b/home-manager/_mixins/nv/pkgs/nico-cli/default.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "nico-cli";
-  version = "2.0.0-rc.4";
+  version = "2.0.0-rc.5";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "infra-controller";
     rev = "v${version}";
-    hash = "sha256-nAG/4UCYys0qWZjdF+tHvuNDa/T0spojKiZMd9AccEY=";
+    hash = "sha256-EPbZHkbAlZoDwp8bW6BRXx2nVVwvXIWTfVrIj+nRZAM=";
   };
 
   modRoot = "./rest-api";


### PR DESCRIPTION
Automated package source update.

Package builds were not run by the updater. Normal CI is expected to validate
whether the updated package still builds or needs follow-up fixes.

| Package | Version | Changelog | Diff |
| --- | --- | --- | --- |
| `nico-cli` | `2.0.0-rc.4 -> 2.0.0-rc.5` | [link](https://github.com/NVIDIA/infra-controller/tree/v2.0.0-rc.5) | [compare](https://github.com/NVIDIA/infra-controller/compare/v2.0.0-rc.4...v2.0.0-rc.5) |

Generated by GitHub Actions.