### PR TITLE
Fix jellystat bootstrap failure on jellyfin not ready

### DIFF
--- a/nixos/beast/jellystat.nix
+++ b/nixos/beast/jellystat.nix
@@ -205,11 +205,15 @@ in
       description = "Bootstrap Jellystat configuration";
       wantedBy = [ "multi-user.target" ];
       wants = [
+        "jellyfin.service"
+        "nginx.service"
         "podman-jellystat.service"
         "postgresql.service"
         "sops-install-secrets.service"
       ];
       after = [
+        "jellyfin.service"
+        "nginx.service"
         "podman-jellystat.service"
         "postgresql.service"
         "sops-install-secrets.service"
@@ -305,7 +309,21 @@ in
         fi
 
         if [ -n "$token" ]; then
-          post_json_auth /api/setconfig "$config_payload" "$token" >/dev/null
+          # setconfig validates the supplied connection by calling Jellyfin's
+          # /system/configuration endpoint, so wait for the API to become ready
+          # after boot rather than relying only on systemd service ordering.
+          for attempt in $(seq 1 120); do
+            if post_json_auth /api/setconfig "$config_payload" "$token" >/dev/null; then
+              break
+            fi
+
+            if [ "$attempt" = 120 ]; then
+              echo "Timed out waiting for Jellyfin setup API" >&2
+              exit 1
+            fi
+
+            sleep 2
+          done
 
           login_payload="$(jq --null-input --compact-output '{ REQUIRE_LOGIN: false }')"
           post_json_auth /api/setRequireLogin "$login_payload" "$token" >/dev/null

--- a/nixos/beast/jellystat.nix
+++ b/nixos/beast/jellystat.nix
@@ -358,12 +358,16 @@ in
     };
 
     podman-jellystat = {
+      # Podman snapshots the host resolver configuration when it creates the
+      # container, so wait for DHCP to populate resolv.conf first.
       wants = [
         "jellystat-postgresql-password.service"
+        "network-online.target"
         "sops-install-secrets.service"
       ];
       after = [
         "jellystat-postgresql-password.service"
+        "network-online.target"
         "sops-install-secrets.service"
       ];
       unitConfig.RequiresMountsFor = [ jellystatBackupDataDir ];

--- a/nixos/org/llm.nix
+++ b/nixos/org/llm.nix
@@ -256,13 +256,17 @@ in
       '';
     };
     podman-litellm = {
+      # Podman snapshots the host resolver configuration when it creates the
+      # container, so wait for DHCP to populate resolv.conf first.
       wants = [
         "litellm-postgresql-password.service"
+        "network-online.target"
         "sops-install-secrets.service"
         "stunnel.service"
       ];
       after = [
         "litellm-postgresql-password.service"
+        "network-online.target"
         "sops-install-secrets.service"
         "stunnel.service"
       ];


### PR DESCRIPTION
- **Wait for Jellyfin before Jellystat bootstrap**
- **Wait for network before DNS-dependent containers**
