### PR TITLE
Enable fallback ssh key for signing

### DIFF
--- a/common/_mixins/yubi.nix
+++ b/common/_mixins/yubi.nix
@@ -39,7 +39,7 @@ in
       remoteFallbackKeyName = lib.mkOption {
         type = lib.types.str;
         default = "id_ed25519";
-        description = "Password-protected SSH key filename under ~/.ssh for SSH login sessions.";
+        description = "Non-interactive SSH fallback key filename under ~/.ssh for remote sessions.";
       };
     };
 

--- a/home-manager/_mixins/hyprland/default.nix
+++ b/home-manager/_mixins/hyprland/default.nix
@@ -75,7 +75,7 @@ in
           inner_color = "rgb(36, 39, 58)";
           outer_color = "rgb(137, 180, 250)";
           outline_thickness = 2;
-          placeholder_text = ''<span foreground="##cad3f5">Password...</span>'';
+          placeholder_text = ''<span foreground="##cad3f5">YubiKey PIN or password...</span>'';
           shadow_passes = 2;
         }
       ];

--- a/home-manager/_mixins/yubi.nix
+++ b/home-manager/_mixins/yubi.nix
@@ -31,6 +31,19 @@ let
           IdentityFile ${yubikeySshKey}
           IdentitiesOnly yes
       '';
+  gitSshSign = pkgs.writeShellScript "git-ssh-sign" ''
+    args=("$@")
+
+    if [[ -n "''${SSH_CONNECTION:-}" ]]; then
+      for ((i = 0; i < ''${#args[@]}; i++)); do
+        if [[ "''${args[i]}" == ${lib.escapeShellArg yubikeySshKey} ]]; then
+          args[i]=${lib.escapeShellArg fallbackSshKey}
+        fi
+      done
+    fi
+
+    exec ${pkgs.openssh}/bin/ssh-keygen "''${args[@]}"
+  '';
   sshSudoAskpass = pkgs.writeShellScript "sudo-ssh-askpass" ''
     prompt="$1"
     [ -n "$prompt" ] || prompt="Password:"
@@ -91,7 +104,10 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf cfg.ssh.enable {
-      programs.git.settings.user.signingKey = yubikeySshKey;
+      programs.git.settings = {
+        gpg.ssh.program = "${gitSshSign}";
+        user.signingKey = yubikeySshKey;
+      };
       programs.ssh.extraConfig = lib.mkAfter localSshIdentityConfig;
     })
 

--- a/home-manager/_mixins/yubi.nix
+++ b/home-manager/_mixins/yubi.nix
@@ -81,7 +81,7 @@ in
       remoteFallbackKeyName = lib.mkOption {
         type = lib.types.str;
         default = "id_ed25519";
-        description = "Password-protected SSH key filename under ~/.ssh for SSH login sessions.";
+        description = "Non-interactive SSH fallback key filename under ~/.ssh for remote sessions.";
       };
     };
 


### PR DESCRIPTION
- **Use fallback Git signing key over SSH**
- **Clarify Hyprlock YubiKey PIN prompt**
- **Document noninteractive SSH fallback key**
