### PR TITLE
Automate uptimerobot syncs

### DIFF
--- a/nixos/pki/default.nix
+++ b/nixos/pki/default.nix
@@ -88,6 +88,7 @@ in
     ./oidc-probes.nix
     ./backup.nix
     ./unifi-sync.nix
+    ./uptimerobot-sync.nix
     ./wg-home-dns-sync.nix
   ];
 

--- a/nixos/pki/pkgs/default.nix
+++ b/nixos/pki/pkgs/default.nix
@@ -5,5 +5,7 @@ pkgs: {
 
   unifi-sync = pkgs.callPackage ./unifi-sync { };
 
+  uptimerobot-sync = pkgs.callPackage ./uptimerobot-sync { };
+
   wg-home-dns-sync = pkgs.callPackage ./wg-home-dns-sync { };
 }

--- a/nixos/pki/pkgs/uptimerobot-sync/default.nix
+++ b/nixos/pki/pkgs/uptimerobot-sync/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  python3,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "uptimerobot-sync";
+  runtimeInputs = [ python3 ];
+  checkPhase = ''
+    runHook preCheck
+    cd "$TMPDIR"
+    cp ${./test_main.py} test_main.py
+    UPTIMEROBOT_SYNC_MAIN=${./main.py} ${python3.pkgs.pytest}/bin/pytest -q -p no:cacheprovider test_main.py
+    runHook postCheck
+  '';
+  text = ''
+    exec ${python3}/bin/python3 ${./main.py} "$@"
+  '';
+
+  meta = {
+    description = "Sync UptimeRobot monitors from Nix service inventory";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ booxter ];
+    mainProgram = "uptimerobot-sync";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/nixos/pki/pkgs/uptimerobot-sync/default.nix
+++ b/nixos/pki/pkgs/uptimerobot-sync/default.nix
@@ -22,6 +22,6 @@ writeShellApplication {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ booxter ];
     mainProgram = "uptimerobot-sync";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = lib.platforms.linux;
   };
 }

--- a/nixos/pki/pkgs/uptimerobot-sync/main.py
+++ b/nixos/pki/pkgs/uptimerobot-sync/main.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+MANAGED_TAG = "nix-inventory"
+SERVICE_TAG_PREFIX = "nix-service-"
+
+
+class UptimeRobotError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Service:
+    id: str
+    title: str
+    url: str
+
+    @property
+    def service_tag(self) -> str:
+        return f"{SERVICE_TAG_PREFIX}{self.id}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="uptimerobot-sync",
+        description="Reconcile UptimeRobot HTTP monitors with Nix service inventory.",
+    )
+    parser.add_argument(
+        "--api-url",
+        default="https://api.uptimerobot.com/v3",
+        help="UptimeRobot API base URL.",
+    )
+    parser.add_argument(
+        "--api-key-file",
+        required=True,
+        help="File containing an UptimeRobot main API key.",
+    )
+    parser.add_argument(
+        "--inventory-json-file",
+        required=True,
+        help="JSON file containing inventory services.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=300,
+        help="Monitor interval in seconds.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned changes without applying them.",
+    )
+    return parser
+
+
+def load_services(path: str) -> list[Service]:
+    try:
+        document = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise UptimeRobotError(f"cannot read inventory JSON: {error}") from error
+
+    if not isinstance(document, list):
+        raise UptimeRobotError("inventory JSON must be an array")
+
+    services: list[Service] = []
+    seen_ids: set[str] = set()
+    seen_urls: set[str] = set()
+    for entry in document:
+        if not isinstance(entry, dict):
+            raise UptimeRobotError("each inventory service must be an object")
+        try:
+            service = Service(
+                id=str(entry["id"]),
+                title=str(entry["title"]),
+                url=str(entry["url"]),
+            )
+        except KeyError as error:
+            raise UptimeRobotError(
+                f"inventory service is missing {error.args[0]}"
+            ) from error
+        if not service.id or not service.title or not service.url:
+            raise UptimeRobotError("inventory service fields must not be empty")
+        if service.id in seen_ids:
+            raise UptimeRobotError(f"duplicate inventory service id: {service.id}")
+        if service.url in seen_urls:
+            raise UptimeRobotError(f"duplicate inventory service URL: {service.url}")
+        seen_ids.add(service.id)
+        seen_urls.add(service.url)
+        services.append(service)
+    return services
+
+
+def tag_names(monitor: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for tag in monitor.get("tags") or []:
+        if isinstance(tag, str):
+            names.add(tag)
+        elif isinstance(tag, dict) and isinstance(tag.get("name"), str):
+            names.add(tag["name"])
+    return names
+
+
+def monitor_service_id(monitor: dict[str, Any]) -> str | None:
+    service_tags = sorted(
+        tag.removeprefix(SERVICE_TAG_PREFIX)
+        for tag in tag_names(monitor)
+        if tag.startswith(SERVICE_TAG_PREFIX)
+    )
+    if len(service_tags) > 1:
+        raise UptimeRobotError(
+            f"monitor {monitor.get('id')} has multiple inventory service tags"
+        )
+    return service_tags[0] if service_tags else None
+
+
+class UptimeRobotClient:
+    def __init__(self, api_url: str, api_key: str):
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        data = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+        for attempt in range(4):
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    body = response.read()
+            except urllib.error.HTTPError as error:
+                if error.code == 429 and attempt < 3:
+                    retry_after = error.headers.get("Retry-After", "1")
+                    try:
+                        delay = max(1, int(retry_after))
+                    except ValueError:
+                        delay = 1
+                    error.close()
+                    time.sleep(delay)
+                    continue
+                detail = error.read().decode(errors="replace")
+                raise UptimeRobotError(
+                    f"UptimeRobot API {method} {path} failed with HTTP {error.code}: {detail}"
+                ) from error
+            except urllib.error.URLError as error:
+                raise UptimeRobotError(
+                    f"UptimeRobot API {method} {path} failed: {error.reason}"
+                ) from error
+            try:
+                return json.loads(body) if body else None
+            except json.JSONDecodeError as error:
+                raise UptimeRobotError(
+                    f"UptimeRobot API {method} {path} returned invalid JSON"
+                ) from error
+        raise AssertionError("unreachable")
+
+    def list_monitors(self) -> list[dict[str, Any]]:
+        response = self.request("GET", "/monitors")
+        if not isinstance(response, dict) or not isinstance(
+            response.get("monitors"), list
+        ):
+            raise UptimeRobotError("UptimeRobot monitor list response is malformed")
+        return response["monitors"]
+
+    def create_monitor(self, payload: dict[str, Any]) -> None:
+        self.request("POST", "/monitors", payload)
+
+    def update_monitor(self, monitor_id: Any, payload: dict[str, Any]) -> None:
+        self.request("PATCH", f"/monitors/{monitor_id}", payload)
+
+    def delete_monitor(self, monitor_id: Any) -> None:
+        self.request("DELETE", f"/monitors/{monitor_id}")
+
+
+def reconcile(
+    client: Any,
+    services: list[Service],
+    interval: int,
+    dry_run: bool = False,
+) -> list[str]:
+    if interval <= 0:
+        raise UptimeRobotError("monitor interval must be positive")
+
+    monitors = client.list_monitors()
+    by_service_id: dict[str, dict[str, Any]] = {}
+    by_url: dict[str, list[dict[str, Any]]] = {}
+    for monitor in monitors:
+        if not isinstance(monitor, dict):
+            raise UptimeRobotError("UptimeRobot returned a non-object monitor")
+        by_url.setdefault(str(monitor.get("url", "")), []).append(monitor)
+        service_id = monitor_service_id(monitor)
+        if MANAGED_TAG in tag_names(monitor) and service_id is not None:
+            if service_id in by_service_id:
+                raise UptimeRobotError(
+                    f"multiple managed monitors claim inventory service {service_id}"
+                )
+            by_service_id[service_id] = monitor
+
+    actions: list[str] = []
+    desired_ids = {service.id for service in services}
+    for service in services:
+        monitor = by_service_id.get(service.id)
+        if monitor is None:
+            candidates = by_url.get(service.url, [])
+            if len(candidates) > 1:
+                raise UptimeRobotError(
+                    f"cannot adopt {service.id}: multiple monitors use {service.url}"
+                )
+            monitor = candidates[0] if candidates else None
+
+        if monitor is None:
+            payload = {
+                "friendlyName": service.title,
+                "type": "HTTP",
+                "url": service.url,
+                "interval": interval,
+                "tagNames": [MANAGED_TAG, service.service_tag],
+            }
+            actions.append(f"create {service.id} ({service.url})")
+            if not dry_run:
+                client.create_monitor(payload)
+            continue
+
+        tags = tag_names(monitor) | {MANAGED_TAG, service.service_tag}
+        desired = {
+            "friendlyName": service.title,
+            "type": "HTTP",
+            "url": service.url,
+            "interval": interval,
+            "tagNames": sorted(tags),
+        }
+        changes = {
+            key: value
+            for key, value in desired.items()
+            if (tag_names(monitor) if key == "tagNames" else monitor.get(key))
+            != (set(value) if key == "tagNames" else value)
+        }
+        if changes:
+            actions.append(f"update {service.id} ({monitor.get('id')})")
+            if not dry_run:
+                client.update_monitor(monitor.get("id"), desired)
+
+    for service_id, monitor in sorted(by_service_id.items()):
+        if service_id in desired_ids:
+            continue
+        actions.append(f"delete {service_id} ({monitor.get('id')})")
+        if not dry_run:
+            client.delete_monitor(monitor.get("id"))
+
+    return actions
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        api_key = Path(args.api_key_file).read_text().strip()
+        if not api_key:
+            raise UptimeRobotError("API key file is empty")
+        services = load_services(args.inventory_json_file)
+        actions = reconcile(
+            UptimeRobotClient(args.api_url, api_key),
+            services,
+            args.interval,
+            args.dry_run,
+        )
+    except (OSError, UptimeRobotError) as error:
+        print(f"uptimerobot-sync: {error}", file=sys.stderr)
+        return 1
+
+    if actions:
+        for action in actions:
+            print(action)
+    else:
+        print("UptimeRobot monitors are already in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nixos/pki/pkgs/uptimerobot-sync/main.py
+++ b/nixos/pki/pkgs/uptimerobot-sync/main.py
@@ -5,16 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-
-MANAGED_TAG = "nix-inventory"
-SERVICE_TAG_PREFIX = "nix-service-"
 
 
 class UptimeRobotError(RuntimeError):
@@ -26,10 +21,6 @@ class Service:
     id: str
     title: str
     url: str
-
-    @property
-    def service_tag(self) -> str:
-        return f"{SERVICE_TAG_PREFIX}{self.id}"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -77,6 +68,7 @@ def load_services(path: str) -> list[Service]:
 
     services: list[Service] = []
     seen_ids: set[str] = set()
+    seen_titles: set[str] = set()
     seen_urls: set[str] = set()
     for entry in document:
         if not isinstance(entry, dict):
@@ -95,35 +87,17 @@ def load_services(path: str) -> list[Service]:
             raise UptimeRobotError("inventory service fields must not be empty")
         if service.id in seen_ids:
             raise UptimeRobotError(f"duplicate inventory service id: {service.id}")
+        if service.title in seen_titles:
+            raise UptimeRobotError(
+                f"duplicate inventory service title: {service.title}"
+            )
         if service.url in seen_urls:
             raise UptimeRobotError(f"duplicate inventory service URL: {service.url}")
         seen_ids.add(service.id)
+        seen_titles.add(service.title)
         seen_urls.add(service.url)
         services.append(service)
     return services
-
-
-def tag_names(monitor: dict[str, Any]) -> set[str]:
-    names: set[str] = set()
-    for tag in monitor.get("tags") or []:
-        if isinstance(tag, str):
-            names.add(tag)
-        elif isinstance(tag, dict) and isinstance(tag.get("name"), str):
-            names.add(tag["name"])
-    return names
-
-
-def monitor_service_id(monitor: dict[str, Any]) -> str | None:
-    service_tags = sorted(
-        tag.removeprefix(SERVICE_TAG_PREFIX)
-        for tag in tag_names(monitor)
-        if tag.startswith(SERVICE_TAG_PREFIX)
-    )
-    if len(service_tags) > 1:
-        raise UptimeRobotError(
-            f"monitor {monitor.get('id')} has multiple inventory service tags"
-        )
-    return service_tags[0] if service_tags else None
 
 
 class UptimeRobotClient:
@@ -148,35 +122,24 @@ class UptimeRobotClient:
                 "Content-Type": "application/json",
             },
         )
-        for attempt in range(4):
-            try:
-                with urllib.request.urlopen(request, timeout=30) as response:
-                    body = response.read()
-            except urllib.error.HTTPError as error:
-                if error.code == 429 and attempt < 3:
-                    retry_after = error.headers.get("Retry-After", "1")
-                    try:
-                        delay = max(1, int(retry_after))
-                    except ValueError:
-                        delay = 1
-                    error.close()
-                    time.sleep(delay)
-                    continue
-                detail = error.read().decode(errors="replace")
-                raise UptimeRobotError(
-                    f"UptimeRobot API {method} {path} failed with HTTP {error.code}: {detail}"
-                ) from error
-            except urllib.error.URLError as error:
-                raise UptimeRobotError(
-                    f"UptimeRobot API {method} {path} failed: {error.reason}"
-                ) from error
-            try:
-                return json.loads(body) if body else None
-            except json.JSONDecodeError as error:
-                raise UptimeRobotError(
-                    f"UptimeRobot API {method} {path} returned invalid JSON"
-                ) from error
-        raise AssertionError("unreachable")
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace")
+            raise UptimeRobotError(
+                f"UptimeRobot API {method} {path} failed with HTTP {error.code}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise UptimeRobotError(
+                f"UptimeRobot API {method} {path} failed: {error.reason}"
+            ) from error
+        try:
+            return json.loads(body) if body else None
+        except json.JSONDecodeError as error:
+            raise UptimeRobotError(
+                f"UptimeRobot API {method} {path} returned invalid JSON"
+            ) from error
 
     def list_monitors(self) -> list[dict[str, Any]]:
         response = self.request("GET", "/monitors")
@@ -206,70 +169,62 @@ def reconcile(
         raise UptimeRobotError("monitor interval must be positive")
 
     monitors = client.list_monitors()
-    by_service_id: dict[str, dict[str, Any]] = {}
-    by_url: dict[str, list[dict[str, Any]]] = {}
+    unmatched: dict[Any, dict[str, Any]] = {}
     for monitor in monitors:
         if not isinstance(monitor, dict):
             raise UptimeRobotError("UptimeRobot returned a non-object monitor")
-        by_url.setdefault(str(monitor.get("url", "")), []).append(monitor)
-        service_id = monitor_service_id(monitor)
-        if MANAGED_TAG in tag_names(monitor) and service_id is not None:
-            if service_id in by_service_id:
-                raise UptimeRobotError(
-                    f"multiple managed monitors claim inventory service {service_id}"
-                )
-            by_service_id[service_id] = monitor
+        monitor_id = monitor.get("id")
+        if monitor_id is None:
+            raise UptimeRobotError("UptimeRobot returned a monitor without an id")
+        if monitor_id in unmatched:
+            raise UptimeRobotError(
+                f"UptimeRobot returned duplicate monitor id {monitor_id}"
+            )
+        unmatched[monitor_id] = monitor
 
     actions: list[str] = []
-    desired_ids = {service.id for service in services}
     for service in services:
-        monitor = by_service_id.get(service.id)
-        if monitor is None:
-            candidates = by_url.get(service.url, [])
-            if len(candidates) > 1:
-                raise UptimeRobotError(
-                    f"cannot adopt {service.id}: multiple monitors use {service.url}"
-                )
-            monitor = candidates[0] if candidates else None
+        candidates = [
+            monitor
+            for monitor in unmatched.values()
+            if monitor.get("url") == service.url
+        ]
+        if not candidates:
+            candidates = [
+                monitor
+                for monitor in unmatched.values()
+                if monitor.get("friendlyName") == service.title
+            ]
+        if len(candidates) > 1:
+            raise UptimeRobotError(
+                f"cannot adopt {service.id}: multiple monitors match its URL or title"
+            )
+        monitor = candidates[0] if candidates else None
 
-        if monitor is None:
-            payload = {
-                "friendlyName": service.title,
-                "type": "HTTP",
-                "url": service.url,
-                "interval": interval,
-                "tagNames": [MANAGED_TAG, service.service_tag],
-            }
-            actions.append(f"create {service.id} ({service.url})")
-            if not dry_run:
-                client.create_monitor(payload)
-            continue
-
-        tags = tag_names(monitor) | {MANAGED_TAG, service.service_tag}
         desired = {
             "friendlyName": service.title,
             "type": "HTTP",
             "url": service.url,
             "interval": interval,
-            "tagNames": sorted(tags),
         }
-        changes = {
-            key: value
-            for key, value in desired.items()
-            if (tag_names(monitor) if key == "tagNames" else monitor.get(key))
-            != (set(value) if key == "tagNames" else value)
-        }
-        if changes:
-            actions.append(f"update {service.id} ({monitor.get('id')})")
+        if monitor is None:
+            actions.append(f"create {service.id} ({service.url})")
             if not dry_run:
-                client.update_monitor(monitor.get("id"), desired)
-
-    for service_id, monitor in sorted(by_service_id.items()):
-        if service_id in desired_ids:
+                client.create_monitor(desired)
             continue
-        actions.append(f"delete {service_id} ({monitor.get('id')})")
+
+        monitor_id = monitor["id"]
+        del unmatched[monitor_id]
+        if any(monitor.get(key) != value for key, value in desired.items()):
+            actions.append(f"update {service.id} ({monitor_id})")
+            if not dry_run:
+                client.update_monitor(monitor_id, desired)
+
+    for monitor_id, monitor in sorted(unmatched.items(), key=lambda item: str(item[0])):
+        label = monitor.get("friendlyName") or monitor.get("url") or "unnamed"
+        actions.append(f"delete {label} ({monitor_id})")
         if not dry_run:
-            client.delete_monitor(monitor.get("id"))
+            client.delete_monitor(monitor_id)
 
     return actions
 

--- a/nixos/pki/pkgs/uptimerobot-sync/test_main.py
+++ b/nixos/pki/pkgs/uptimerobot-sync/test_main.py
@@ -1,0 +1,205 @@
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+
+
+MODULE_PATH = pathlib.Path(
+    os.environ.get("UPTIMEROBOT_SYNC_MAIN", pathlib.Path(__file__).with_name("main.py"))
+)
+SPEC = importlib.util.spec_from_file_location("uptimerobot_sync", MODULE_PATH)
+uptimerobot_sync = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = uptimerobot_sync
+SPEC.loader.exec_module(uptimerobot_sync)
+
+
+class FakeClient:
+    def __init__(self, monitors):
+        self.monitors = monitors
+        self.created = []
+        self.updated = []
+        self.deleted = []
+
+    def list_monitors(self):
+        return self.monitors
+
+    def create_monitor(self, payload):
+        self.created.append(payload)
+
+    def update_monitor(self, monitor_id, payload):
+        self.updated.append((monitor_id, payload))
+
+    def delete_monitor(self, monitor_id):
+        self.deleted.append(monitor_id)
+
+
+def service(id="search", title="Search", url="https://search.example/health"):
+    return uptimerobot_sync.Service(id=id, title=title, url=url)
+
+
+def test_create_missing_monitor():
+    client = FakeClient([])
+
+    actions = uptimerobot_sync.reconcile(client, [service()], 300)
+
+    assert actions == ["create search (https://search.example/health)"]
+    assert client.created == [
+        {
+            "friendlyName": "Search",
+            "type": "HTTP",
+            "url": "https://search.example/health",
+            "interval": 300,
+            "tagNames": ["nix-inventory", "nix-service-search"],
+        }
+    ]
+
+
+def test_adopt_monitor_by_url_and_preserve_existing_tags():
+    client = FakeClient(
+        [
+            {
+                "id": 42,
+                "friendlyName": "Old name",
+                "type": "HTTP",
+                "url": "https://search.example/health",
+                "interval": 300,
+                "tags": [{"name": "personal"}],
+            }
+        ]
+    )
+
+    uptimerobot_sync.reconcile(client, [service()], 300)
+
+    assert client.updated == [
+        (
+            42,
+            {
+                "friendlyName": "Search",
+                "type": "HTTP",
+                "url": "https://search.example/health",
+                "interval": 300,
+                "tagNames": ["nix-inventory", "nix-service-search", "personal"],
+            },
+        )
+    ]
+
+
+def test_update_managed_monitor_by_service_tag_when_url_changes():
+    client = FakeClient(
+        [
+            {
+                "id": 7,
+                "friendlyName": "Search",
+                "type": "HTTP",
+                "url": "https://old.example/health",
+                "interval": 300,
+                "tags": ["nix-inventory", "nix-service-search"],
+            }
+        ]
+    )
+
+    uptimerobot_sync.reconcile(client, [service()], 300)
+
+    assert client.updated == [
+        (
+            7,
+            {
+                "friendlyName": "Search",
+                "type": "HTTP",
+                "url": "https://search.example/health",
+                "interval": 300,
+                "tagNames": ["nix-inventory", "nix-service-search"],
+            },
+        )
+    ]
+    assert client.created == []
+    assert client.deleted == []
+
+
+def test_delete_only_stale_managed_monitor():
+    client = FakeClient(
+        [
+            {
+                "id": 1,
+                "url": "https://old.example",
+                "tags": ["nix-inventory", "nix-service-old"],
+            },
+            {
+                "id": 2,
+                "url": "https://manual.example",
+                "tags": ["personal"],
+            },
+        ]
+    )
+
+    actions = uptimerobot_sync.reconcile(client, [], 300)
+
+    assert actions == ["delete old (1)"]
+    assert client.deleted == [1]
+
+
+def test_noop_when_monitor_matches():
+    client = FakeClient(
+        [
+            {
+                "id": 7,
+                "friendlyName": "Search",
+                "type": "HTTP",
+                "url": "https://search.example/health",
+                "interval": 300,
+                "tags": ["nix-inventory", "nix-service-search"],
+            }
+        ]
+    )
+
+    assert uptimerobot_sync.reconcile(client, [service()], 300) == []
+    assert client.updated == []
+
+
+def test_dry_run_does_not_mutate():
+    client = FakeClient([])
+
+    actions = uptimerobot_sync.reconcile(client, [service()], 300, dry_run=True)
+
+    assert actions == ["create search (https://search.example/health)"]
+    assert client.created == []
+
+
+def test_ambiguous_adoption_fails():
+    client = FakeClient(
+        [
+            {"id": 1, "url": "https://search.example/health"},
+            {"id": 2, "url": "https://search.example/health"},
+        ]
+    )
+
+    with pytest.raises(uptimerobot_sync.UptimeRobotError, match="multiple monitors"):
+        uptimerobot_sync.reconcile(client, [service()], 300)
+
+
+def test_client_lists_v3_monitors_with_bearer_auth(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return json.dumps({"monitors": [{"id": 17}]}).encode()
+
+    def urlopen(request, timeout):
+        assert request.full_url == "https://api.example/v3/monitors"
+        assert request.get_header("Authorization") == "Bearer secret"
+        assert timeout == 30
+        return Response()
+
+    monkeypatch.setattr(uptimerobot_sync.urllib.request, "urlopen", urlopen)
+
+    client = uptimerobot_sync.UptimeRobotClient("https://api.example/v3", "secret")
+
+    assert client.list_monitors() == [{"id": 17}]

--- a/nixos/pki/pkgs/uptimerobot-sync/test_main.py
+++ b/nixos/pki/pkgs/uptimerobot-sync/test_main.py
@@ -53,12 +53,11 @@ def test_create_missing_monitor():
             "type": "HTTP",
             "url": "https://search.example/health",
             "interval": 300,
-            "tagNames": ["nix-inventory", "nix-service-search"],
         }
     ]
 
 
-def test_adopt_monitor_by_url_and_preserve_existing_tags():
+def test_adopt_monitor_by_url():
     client = FakeClient(
         [
             {
@@ -67,7 +66,6 @@ def test_adopt_monitor_by_url_and_preserve_existing_tags():
                 "type": "HTTP",
                 "url": "https://search.example/health",
                 "interval": 300,
-                "tags": [{"name": "personal"}],
             }
         ]
     )
@@ -82,13 +80,12 @@ def test_adopt_monitor_by_url_and_preserve_existing_tags():
                 "type": "HTTP",
                 "url": "https://search.example/health",
                 "interval": 300,
-                "tagNames": ["nix-inventory", "nix-service-search", "personal"],
             },
         )
     ]
 
 
-def test_update_managed_monitor_by_service_tag_when_url_changes():
+def test_adopt_monitor_by_title_when_url_changes():
     client = FakeClient(
         [
             {
@@ -97,7 +94,6 @@ def test_update_managed_monitor_by_service_tag_when_url_changes():
                 "type": "HTTP",
                 "url": "https://old.example/health",
                 "interval": 300,
-                "tags": ["nix-inventory", "nix-service-search"],
             }
         ]
     )
@@ -112,7 +108,6 @@ def test_update_managed_monitor_by_service_tag_when_url_changes():
                 "type": "HTTP",
                 "url": "https://search.example/health",
                 "interval": 300,
-                "tagNames": ["nix-inventory", "nix-service-search"],
             },
         )
     ]
@@ -120,26 +115,26 @@ def test_update_managed_monitor_by_service_tag_when_url_changes():
     assert client.deleted == []
 
 
-def test_delete_only_stale_managed_monitor():
+def test_delete_all_monitors_absent_from_inventory():
     client = FakeClient(
         [
             {
                 "id": 1,
+                "friendlyName": "Old",
                 "url": "https://old.example",
-                "tags": ["nix-inventory", "nix-service-old"],
             },
             {
                 "id": 2,
+                "friendlyName": "Manual",
                 "url": "https://manual.example",
-                "tags": ["personal"],
             },
         ]
     )
 
     actions = uptimerobot_sync.reconcile(client, [], 300)
 
-    assert actions == ["delete old (1)"]
-    assert client.deleted == [1]
+    assert actions == ["delete Old (1)", "delete Manual (2)"]
+    assert client.deleted == [1, 2]
 
 
 def test_noop_when_monitor_matches():
@@ -151,7 +146,6 @@ def test_noop_when_monitor_matches():
                 "type": "HTTP",
                 "url": "https://search.example/health",
                 "interval": 300,
-                "tags": ["nix-inventory", "nix-service-search"],
             }
         ]
     )

--- a/nixos/pki/uptimerobot-sync.nix
+++ b/nixos/pki/uptimerobot-sync.nix
@@ -1,0 +1,84 @@
+{
+  config,
+  hostInventory,
+  lib,
+  pkiPkgs,
+  pkgs,
+  ...
+}:
+let
+  servicesFile = pkgs.writeText "uptimerobot-services.json" (
+    builtins.toJSON (
+      map (service: {
+        inherit (service) id title;
+        url = service.probeUrl;
+      }) hostInventory.publicServices
+    )
+  );
+in
+{
+  users.users.uptimerobot-sync = {
+    isSystemUser = true;
+    group = "uptimerobot-sync";
+  };
+
+  users.groups.uptimerobot-sync = { };
+
+  sops.secrets.uptimeRobotApiKey = {
+    key = "uptimerobot/api_key";
+    owner = "uptimerobot-sync";
+    group = "uptimerobot-sync";
+    mode = "0400";
+    restartUnits = [ "uptimerobot-sync.service" ];
+  };
+
+  systemd.services.uptimerobot-sync = {
+    description = "Sync UptimeRobot monitors from service inventory";
+    wants = [
+      "network-online.target"
+      "sops-install-secrets.service"
+    ];
+    after = [
+      "network-online.target"
+      "sops-install-secrets.service"
+    ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "uptimerobot-sync";
+      Group = "uptimerobot-sync";
+      ExecStart = "${lib.getExe pkiPkgs.uptimerobot-sync} ${
+        lib.escapeShellArgs [
+          "--api-key-file"
+          config.sops.secrets.uptimeRobotApiKey.path
+          "--inventory-json-file"
+          servicesFile
+        ]
+      }";
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+      ProtectHome = true;
+      ProtectSystem = "strict";
+      ProtectControlGroups = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+      ];
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+    };
+  };
+
+  systemd.timers.uptimerobot-sync = {
+    description = "Periodically sync UptimeRobot monitors from service inventory";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "5m";
+      OnUnitActiveSec = "1h";
+      RandomizedDelaySec = "10m";
+      Persistent = true;
+      Unit = "uptimerobot-sync.service";
+    };
+  };
+}

--- a/secrets/_templates/pki.yaml
+++ b/secrets/_templates/pki.yaml
@@ -8,6 +8,9 @@ backup:
 unifi:
   api_key: "REPLACE_ME"
 
+uptimerobot:
+  api_key: "REPLACE_ME"
+
 github:
   pki_rotation:
     token: "REPLACE_ME"

--- a/secrets/pki.yaml
+++ b/secrets/pki.yaml
@@ -221,6 +221,8 @@ users:
         hashedPassword: ENC[AES256_GCM,data:aXhFZCONb4iR1yUq0xUYhFkypKJof9Ik1pJ1sqgJQwgWmqgwqaGDJcwuEHiDk3/MPoDKUb1rnutrlGcJ6UsRwS1nwQ7/pSnEG5vl5MsmBOl+no59iLim8Lzz+keQgijO+Uf5Jovh225thg==,iv:mRHBfpC/1O33aAZXojcSH782OmToNiTzPdYUB1kbd6U=,tag:Px1qPuKdLmCniUOO6A+pMA==,type:str]
     root:
         hashedPassword: ENC[AES256_GCM,data:ZcyvMYuowOXHuJTr+bNpCsLB2BWPgzlMv+cuhZVzi7QrBLbJeAiEUUOd8bQz5PUOsZfUt5V72xVM1PX3q1ORf3vMroR7HTGsfNpxU0RuXF3BzQv6FhXItWGJ+TxUAvSCC8/zseCbUjTlRw==,iv:TlMIV1itP/YW6+rK9Bd3EWoNnPh89J2rV7wfbKbsf24=,tag:5F959VqIt9eJIy1IeM+w7g==,type:str]
+uptimerobot:
+    api_key: ENC[AES256_GCM,data:yUluJK+kopi7WVOEowWiPagMtXzkRh/09n0nKMJWQ8Oo,iv:Z/dQKr8LYqyb4JtbFvwm3awKDMa+4mFTic9t8vzjxbI=,tag:6TWZeRpkHnD1cQDIAY5hrQ==,type:str]
 sops:
     age:
         - enc: |
@@ -261,7 +263,7 @@ sops:
             HUE=
             -----END AGE ENCRYPTED FILE-----
           recipient: age1yubikey1qgnnyzk9ftl6uetyk6r8kd8eqxe7emcsgedaq7jycjk6sxt483p55chyk9r
-    lastmodified: "2026-07-12T04:15:20Z"
-    mac: ENC[AES256_GCM,data:L6NobB/hORpWHK58P5hJ/JWu53bs1PWv9LZrxVgwCWgrYjzbe8+ya81NU79a4eHmQplGc9AsWHMMYj2i/VofmtB2zJbDoolZ2RN9u+K0iKxsiClxMgKuf0KvtYvpuoGdzZe3+jUbB6ZNaiVLcmaiE6r2BoFcjtlYeuXLmpuAgAE=,iv:iAiFsYE0gabOW76c8jzimv42D/FLWit80wL3Nq2ATIU=,tag:m4OjOS+PEMJXwTfLHy0ScQ==,type:str]
+    lastmodified: "2026-07-12T23:28:52Z"
+    mac: ENC[AES256_GCM,data:cPh+ZQn7OsUUJSbOtAgVF3swA9997a35W67ecOCNUZrrC61aWwSPLvQST1nFzBTrTxzRsV91eEROkagFPNUDPavqw5YA7192IQ3FoLx+Fu9Y1gC6yAmg1Je94ef4PObIlBz6g8EBv2CBToYZuU4KYWGIrk7vFbgIY+nkhjyXeG8=,iv:3vUGl/YxAiQleeNHQOlV5nbu32ffRje/3kbeQhgEgg0=,tag:W9er9fcJMBGtdiREKGhxFg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.13.1
+    version: 3.13.2


### PR DESCRIPTION
## Summary
- Add a new `uptimerobot-sync` package that reconciles UptimeRobot HTTP monitors against the Nix service inventory.
- Wire the sync into the PKI NixOS module set with a systemd oneshot service and periodic timer.
- Add the UptimeRobot API key template entry for sops-managed secrets.
- Cover reconciliation behavior with unit tests for create, adopt, update, delete, dry-run, and API client auth/listing.

## Testing
- Added pytest coverage for the sync logic and API client behavior.
- Not run (not requested).